### PR TITLE
Added initial `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing Guidelines
+
+Thank you for your interest in contributing! This repository contains Jupyter
+notebooks that demonstrate usage examples for the latest generation of ESA 
+EOPF data product formats and the various libraries to utilize them.
+To ensure consistency and readability, please adhere to the following 
+guidelines.
+
+## Code Style and Formatting
+
+### General Formatting
+
+- Use **Black** (with default settings) for automatic code formatting.
+- Ensure your code is clean, well-structured, and follows best practices.
+
+### Naming Conventions (PEP 8)
+
+- **Variables:** Use `snake_case` (e.g., `coordinate_reference_system`).
+- **Functions:** Use `snake_case` (e.g., `open_dataset()`).
+- **Classes:** Use `CamelCase` (e.g., `Sentine3DataProduct`).
+
+See [PEP 8 – Style Guide for Python Code](https://peps.python.org/pep-0008/) 
+for details.
+
+## Formatting Jupyter Notebooks
+
+To format Jupyter notebooks using Black, install the necessary package and 
+run the following command:
+
+```sh
+pip install black[jupyter]
+black --preview --quiet notebooks/
+```
+
+## How to Contribute
+
+1. Ensure your code follows the style guidelines outlined above.
+2. Run all notebook cells to verify correctness before submitting.
+3. Always create a **pull request**—do not push directly to the `main` branch.
+4. Open a pull request with a clear description of your changes.
+
+We appreciate your contributions — happy coding! 🚀
+


### PR DESCRIPTION
Here comes a basic contribution guide. What could be added too is:

- rules like: 
   - always have a markdown header following given template: ...
   - don't use Python code comments to explain following cells, always use markdown cells
   - ... 
- force that every PR should have an associated issue

I would also find it useful if we include a link to an example notebook that can serve as a template for new ones:
https://eopf-sample-service.github.io/eopf-sample-notebooks/template

Here are two interesting, way more detailed Jupyter notebook style guides which we could directly adhere to, or borrow from, or just refer to as recommended reads:

- [Google Jupyter Notebook Manifesto](https://cloud.google.com/blog/products/ai-machine-learning/best-practices-that-can-improve-the-life-of-any-developer-using-jupyter-notebooks?hl=en)
- [Jupyter Notebook Best Practices](https://medium.com/towards-data-science/jupyter-notebook-best-practices-f430a6ba8c69)
