### PR TITLE
Update import xcube-eopf

### DIFF
--- a/notebooks/performance/sentinel_performance_zarr_safe_xcube.ipynb
+++ b/notebooks/performance/sentinel_performance_zarr_safe_xcube.ipynb
@@ -124,7 +124,7 @@
     "import requests\n",
     "\n",
     "from xcube.core.store import new_data_store\n",
-    "from xcube_eopf.utils import reproject_bbox\n",
+    "from xcube_resampling.utils import reproject_bbox\n",
     "\n",
     "# for benchmarking\n",
     "from dataclasses import dataclass\n",


### PR DESCRIPTION
I updated this notebook to fix the outdated import of a function. The last past using CDSE keys doesn't work any more though, could either @przell or @konstntokas try it when you can?