### PR TITLE
fix: remove invalid [tool.ruff] wrapper from .ruff.toml

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,2 +1,1 @@
-[tool.ruff]
 ignore = ["F401"]


### PR DESCRIPTION
Standalone `.ruff.toml` does not support the `[tool.ruff]` section header — that syntax is only valid inside `pyproject.toml`. This was causing ruff to crash with exit code 2 on all PRs.