### PR TITLE
Correct subtitle for xarray EOPF and xcube EOPF notebooks

### DIFF
--- a/notebooks/xarray_eopf_plugin/introduction.ipynb
+++ b/notebooks/xarray_eopf_plugin/introduction.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "---\n",
     "title: Intoduction to the xarray EOPF backend\n",
-    "Subtitle: Access and explore analysis-ready and native EOPF Zarr data using xarray\n",
+    "subtitle: Access and explore analysis-ready and native EOPF Zarr data using xarray\n",
     "authors:\n",
     "  - name: Konstantin Ntokas\n",
     "    orcid: 0000-0002-0049-0690\n",

--- a/notebooks/xarray_eopf_plugin/sentinel_1_native.ipynb
+++ b/notebooks/xarray_eopf_plugin/sentinel_1_native.ipynb
@@ -6,8 +6,8 @@
    "metadata": {},
    "source": [
     "---\n",
-    "title: xarray EOPF backend - Sentinel-1\n",
-    "Subtitle: Access Sentinel-1 in Native Mode\n",
+    "title: xarray EOPF backend - Sentinel-1 Native Mode\n",
+    "subtitle: Learn how to access Sentinel-1 products in native mode\n",
     "authors:\n",
     "  - name: Konstantin Ntokas\n",
     "    orcid: 0000-0002-0049-0690\n",

--- a/notebooks/xarray_eopf_plugin/sentinel_2_analysis.ipynb
+++ b/notebooks/xarray_eopf_plugin/sentinel_2_analysis.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "---\n",
     "title: xarray EOPF backend - Sentinel-2 Analysis Mode\n",
-    "Subtitle: Access Sentinel-2 in Analysis Mode\n",
+    "subtitle: Learn how to access Sentinel-2 products in analysis mode\n",
     "authors:\n",
     "  - name: Konstantin Ntokas\n",
     "    orcid: 0000-0002-0049-0690\n",

--- a/notebooks/xarray_eopf_plugin/sentinel_2_native.ipynb
+++ b/notebooks/xarray_eopf_plugin/sentinel_2_native.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "---\n",
     "title: xarray EOPF backend - Sentinel-2 Native mode\n",
-    "Subtitle: Access Sentinel-2 in Native Mode\n",
+    "subtitle: Learn how to access Sentinel-2 products in native mode\n",
     "authors:\n",
     "  - name: Konstantin Ntokas\n",
     "    orcid: 0000-0002-0049-0690\n",

--- a/notebooks/xarray_eopf_plugin/sentinel_3_analysis.ipynb
+++ b/notebooks/xarray_eopf_plugin/sentinel_3_analysis.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "---\n",
     "title: xarray EOPF backend - Sentinel-3 Analysis Mode\n",
-    "Subtitle: Access Sentinel-3 in Analysis Mode\n",
+    "subtitle: Learn how to access Sentinel-3 products in analysis mode\n",
     "authors:\n",
     "  - name: Konstantin Ntokas\n",
     "    orcid: 0000-0002-0049-0690\n",
@@ -16404,7 +16404,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/xarray_eopf_plugin/sentinel_3_native.ipynb
+++ b/notebooks/xarray_eopf_plugin/sentinel_3_native.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "---\n",
     "title: xarray EOPF backend - Sentinel-3 Native Mode\n",
-    "Subtitle: Access Sentinel-3 in Native Mode\n",
+    "subtitle: Learn how to access Sentinel-3 products in native mode\n",
     "authors:\n",
     "  - name: Konstantin Ntokas\n",
     "    orcid: 0000-0002-0049-0690\n",

--- a/notebooks/xcube_eopf_plugin/introduction.ipynb
+++ b/notebooks/xcube_eopf_plugin/introduction.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "---\n",
     "title: Introduction to the xcube EOPF Data Store\n",
-    "subtitle: Learn how to building analysis-ready data cubes from multiple EOPF Zarr samples.\n",
+    "subtitle: Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.\n",
     "authors:\n",
     "  - name: Konstantin Ntokas\n",
     "    orcid: 0000-0002-0049-0690\n",

--- a/notebooks/xcube_eopf_plugin/introduction.ipynb
+++ b/notebooks/xcube_eopf_plugin/introduction.ipynb
@@ -6,8 +6,8 @@
    "metadata": {},
    "source": [
     "---\n",
-    "Title: Introduction to the xcube EOPF Data Store\n",
-    "Subtitle: Building Analysis-Ready Data Cubes from multiple EOPF Zarr Tiles\n",
+    "title: Introduction to the xcube EOPF Data Store\n",
+    "subtitle: Learn how to building analysis-ready data cubes from multiple EOPF Zarr samples.\n",
     "authors:\n",
     "  - name: Konstantin Ntokas\n",
     "    orcid: 0000-0002-0049-0690\n",

--- a/notebooks/xcube_eopf_plugin/sentinel_2.ipynb
+++ b/notebooks/xcube_eopf_plugin/sentinel_2.ipynb
@@ -6,8 +6,8 @@
    "metadata": {},
    "source": [
     "---\n",
-    "title: Building Sentinel-2 Data Cubes with xcube EOPF\n",
-    "subtitle: From Multiple EOPF Zarr Tiles to Analysis-Ready Data Cubes (ARDCs)\n",
+    "title: Building Sentinel-2 Data Cubes with xcube EOPF Data Store\n",
+    "subtitle: Learn how to building analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.\n",
     "authors:\n",
     "  - name: Konstantin Ntokas\n",
     "    orcid: 0000-0002-0049-0690\n",

--- a/notebooks/xcube_eopf_plugin/sentinel_2.ipynb
+++ b/notebooks/xcube_eopf_plugin/sentinel_2.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "---\n",
     "title: Building Sentinel-2 Data Cubes with xcube EOPF Data Store\n",
-    "subtitle: Learn how to building analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.\n",
+    "subtitle: Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.\n",
     "authors:\n",
     "  - name: Konstantin Ntokas\n",
     "    orcid: 0000-0002-0049-0690\n",

--- a/notebooks/xcube_eopf_plugin/sentinel_3.ipynb
+++ b/notebooks/xcube_eopf_plugin/sentinel_3.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "---\n",
     "title: Building Sentinel-3 Data Cubes with xcube EOPF Data Store\n",
-    "subtitle: Learn how to building analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.\n",
+    "subtitle: Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.\n",
     "authors:\n",
     "  - name: Konstantin Ntokas\n",
     "    orcid: 0000-0002-0049-0690\n",

--- a/notebooks/xcube_eopf_plugin/sentinel_3.ipynb
+++ b/notebooks/xcube_eopf_plugin/sentinel_3.ipynb
@@ -6,8 +6,8 @@
    "metadata": {},
    "source": [
     "---\n",
-    "title: Building Sentinel-3 Data Cubes with xcube EOPF\n",
-    "subtitle: From Multiple EOPF Zarr Tiles to Analysis-Ready Data Cubes (ARDCs)\n",
+    "title: Building Sentinel-3 Data Cubes with xcube EOPF Data Store\n",
+    "subtitle: Learn how to building analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.\n",
     "authors:\n",
     "  - name: Konstantin Ntokas\n",
     "    orcid: 0000-0002-0049-0690\n",


### PR DESCRIPTION
Subtitle are not presented, as shown in the follwoing image:

<img width="697" height="562" alt="Screenshot from 2026-04-02 17-38-10" src="https://github.com/user-attachments/assets/9970010e-084c-463f-88ff-1faed34ce832" />

I also revised the subtitles to be more consistent with other notebooks. 