### PR TITLE
feat: adopt notebook-card rendering scheme (#241)

### DIFF
--- a/generate_gallery.py
+++ b/generate_gallery.py
@@ -301,7 +301,7 @@ def generate_notebook_card_html(path, meta):
 def wrap_notebook_cards(cards_html):
     """Wrap a list of notebook-card HTML strings in a flex column container."""
     joined = "\n".join(cards_html)
-    return f'<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">\n{joined}\n</div>'
+    return f'<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px; margin-bottom: 40px;">\n{joined}\n</div>'
 
 
 def generate_gallery_pages(notebook_tags, output_dir="notebooks"):

--- a/generate_gallery.py
+++ b/generate_gallery.py
@@ -251,6 +251,59 @@ def render_simple_tags(tags, has_explicit_tags=False, max_visible=3):
     return tag_text
 
 
+DEFAULT_THUMBNAIL = "/notebooks/static/EOPF-on-bright-baseline.png"
+
+
+def _normalize_thumbnail(thumbnail):
+    """Normalize a thumbnail path to a root-relative or absolute URL."""
+    if not thumbnail:
+        return DEFAULT_THUMBNAIL
+    # Absolute URLs pass through unchanged
+    if thumbnail.startswith("http://") or thumbnail.startswith("https://"):
+        return thumbnail
+    # Normalize relative paths: strip leading dots/slashes, then prepend /notebooks/
+    thumb = thumbnail.replace("\\", "/")
+    # Handle paths like ../static/x.png or ./static/x.png
+    if "static/" in thumb:
+        return "/notebooks/static/" + thumb.split("static/", 1)[1]
+    # Generic fallback: make root-relative
+    return "/" + thumb.lstrip("./")
+
+
+def generate_notebook_card_html(path, meta):
+    """Generate a DestinE-style notebook-card HTML block for a single notebook."""
+    title = meta.get("title", path.split("/")[-1].replace("-", " ").replace("_", " ").title())
+    subtitle = meta.get("description", "")
+    tags = meta.get("tags", [])
+    thumbnail = _normalize_thumbnail(meta.get("thumbnail", ""))
+
+    tags_html = "".join(f'<span class="tag">{tag}</span>' for tag in tags)
+    data_tags = " ".join(tags)
+    # MyST page URL: leading slash + notebooks/ prefix + path (no .ipynb extension)
+    href = f"/notebooks/{path}"
+
+    return f'''\
+<div class="notebook-card" data-tags="{data_tags}" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="{thumbnail}" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>{title}</strong><br>
+    {subtitle}
+    <div style="margin: 6px 0;">
+      {tags_html}
+    </div>
+    <a href="{href}" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>'''
+
+
+def wrap_notebook_cards(cards_html):
+    """Wrap a list of notebook-card HTML strings in a flex column container."""
+    joined = "\n".join(cards_html)
+    return f'<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">\n{joined}\n</div>'
+
+
 def generate_gallery_pages(notebook_tags, output_dir="notebooks"):
     """Generate MyST gallery pages with enhanced styling"""
 

--- a/generate_gallery.py
+++ b/generate_gallery.py
@@ -400,8 +400,21 @@ Click on the category to explore the corresponding notebooks!
 
 """)
 
+    def _cards_for_tag(tag):
+        """Return sorted notebook-card HTML strings for notebooks matching a tag."""
+        matched = [
+            (path, meta)
+            for path, meta in notebook_tags.items()
+            if tag in meta.get("tags", [])
+        ]
+        matched.sort(key=lambda x: x[1].get("title", "").lower())
+        return [generate_notebook_card_html(path, meta) for path, meta in matched]
+
     # Generate Sentinel category page
     with open(categories["sentinel"]["file"], "w") as f:
+        s1_cards = wrap_notebook_cards(_cards_for_tag("sentinel-1"))
+        s2_cards = wrap_notebook_cards(_cards_for_tag("sentinel-2"))
+        s3_cards = wrap_notebook_cards(_cards_for_tag("sentinel-3"))
         f.write(f"""---
 title: {categories["sentinel"]["title"]}
 ---
@@ -416,29 +429,24 @@ title: {categories["sentinel"]["title"]}
 
 ## Sentinel-1
 
-```{{gallery-grid}}
-:category: sentinel-1
-:columns: 1 1 2 3
-```
+{s1_cards}
 
 ## Sentinel-2
 
-```{{gallery-grid}}
-:category: sentinel-2
-:columns: 1 1 2 3
-```
+{s2_cards}
 
 ## Sentinel-3
 
-```{{gallery-grid}}
-:category: sentinel-3
-:columns: 1 1 2 3
-```
+{s3_cards}
 
 """)
 
     # Generate Topics category page
     with open(categories["topics"]["file"], "w") as f:
+        land_cards = wrap_notebook_cards(_cards_for_tag("land"))
+        climate_cards = wrap_notebook_cards(_cards_for_tag("climate-change"))
+        marine_cards = wrap_notebook_cards(_cards_for_tag("marine"))
+        security_cards = wrap_notebook_cards(_cards_for_tag("security"))
         f.write(f"""---
 title: {categories["topics"]["title"]}
 ---
@@ -450,41 +458,33 @@ title: {categories["topics"]["title"]}
 <a class="link" href="gallery-topics#marine-applications" ><p style="background-color:white;"><span class="gallery-tag tag-marine">🌊 marine</span></p></a>
 <a class="link" href="gallery-topics#emergency-and-security-applications" ><p style="background-color:white;"><span class="gallery-tag tag-security">🔒 security</span></p></a>
 
-
 {categories["topics"]["description"]}
 
 ## Land Applications
 
-```{{gallery-grid}}
-:category: land
-:columns: 1 1 2 3
-```
+{land_cards}
 
 ## Climate Monitoring
 
-```{{gallery-grid}}
-:category: climate-change
-:columns: 1 1 2 3
-```
+{climate_cards}
 
 ## Marine Applications
 
-```{{gallery-grid}}
-:category: marine
-:columns: 1 1 2 3
-```
+{marine_cards}
 
 ## Emergency and Security Applications
 
-```{{gallery-grid}}
-:category: security
-:columns: 1 1 2 3
-```
+{security_cards}
 
 """)
 
     # Generate Tools category page
     with open(categories["tools"]["file"], "w") as f:
+        xarray_cards = wrap_notebook_cards(_cards_for_tag("xarray"))
+        xarray_eopf_cards = wrap_notebook_cards(_cards_for_tag("xarray-eopf"))
+        xcube_cards = wrap_notebook_cards(_cards_for_tag("xcube"))
+        gdal_cards = wrap_notebook_cards(_cards_for_tag("gdal"))
+        stac_cards = wrap_notebook_cards(_cards_for_tag("stac"))
         f.write(f"""---
 title: {categories["tools"]["title"]}
 ---
@@ -500,43 +500,30 @@ title: {categories["tools"]["title"]}
 
 ## Xarray
 
-```{{gallery-grid}}
-:category: xarray
-:columns: 1 1 2 3
-```
+{xarray_cards}
 
 ## xarray-eopf plugin
 
-```{{gallery-grid}}
-:category: xarray-eopf
-:columns: 1 1 2 3
-```
+{xarray_eopf_cards}
 
 ## xcube-eopf plugin
 
-```{{gallery-grid}}
-:category: xcube
-:columns: 1 1 2 3
-```
+{xcube_cards}
 
 ## GDAL
 
-```{{gallery-grid}}
-:category: gdal
-:columns: 1 1 2 3
-```
+{gdal_cards}
 
 ## STAC
 
-```{{gallery-grid}}
-:category: stac
-:columns: 1 1 2 3
-```
+{stac_cards}
 
 """)
 
     # Generate Tutorials category page
     with open(categories["tutorials"]["file"], "w") as f:
+        dask_cards = wrap_notebook_cards(_cards_for_tag("dask"))
+        basic_cards = wrap_notebook_cards(_cards_for_tag("basic"))
         f.write(f"""---
 title: {categories["tutorials"]["title"]}
 ---
@@ -550,19 +537,13 @@ title: {categories["tutorials"]["title"]}
 
 ## Dask
 
-```{{gallery-grid}}
-:category: dask
-:columns: 1 1 2 3
-```
+{dask_cards}
 
 ## Basic Data Access
 
-```{{gallery-grid}}
-:category: basic
-:columns: 1 1 2 3
-```
+{basic_cards}
 
-        """)
+""")
 
 
 def analyze_notebook_content(notebook_tags):

--- a/generate_gallery.py
+++ b/generate_gallery.py
@@ -282,6 +282,7 @@ def generate_notebook_card_html(path, meta):
     # MyST page URL: leading slash + notebooks/ prefix + path (no .ipynb extension)
     href = f"/notebooks/{path}"
 
+    subtitle_html = f"    {subtitle}<br>\n" if subtitle else ""
     return f'''\
 <div class="notebook-card" data-tags="{data_tags}" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
@@ -289,8 +290,7 @@ def generate_notebook_card_html(path, meta):
   </div>
   <div style="flex: 1;">
     <strong>{title}</strong><br>
-    {subtitle}
-    <div style="margin: 6px 0;">
+{subtitle_html}    <div style="margin: 6px 0;">
       {tags_html}
     </div>
     <a href="{href}" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>

--- a/generate_gallery.py
+++ b/generate_gallery.py
@@ -25,6 +25,7 @@ def extract_notebook_metadata_and_content(notebook_path):
         explicit_subtitle = None
         explicit_authors = []
         explicit_keywords = None
+        explicit_thumbnail = None
 
         # Process cells - only look for YAML frontmatter in first markdown cell
         for cell in nb.cells:
@@ -63,6 +64,8 @@ def extract_notebook_metadata_and_content(notebook_path):
                                     )
                             if "authors" in frontmatter:
                                 explicit_authors = frontmatter["authors"]
+                            if "thumbnail" in frontmatter:
+                                explicit_thumbnail = str(frontmatter["thumbnail"]).strip()
 
                             # Look for tags in frontmatter
                             if "tags" in frontmatter:
@@ -109,6 +112,7 @@ def extract_notebook_metadata_and_content(notebook_path):
             "explicit_subtitle": explicit_subtitle,
             "explicit_authors": explicit_authors,
             "explicit_keywords": explicit_keywords,
+            "explicit_thumbnail": explicit_thumbnail,
         }
 
     except Exception as e:
@@ -122,6 +126,7 @@ def extract_notebook_metadata_and_content(notebook_path):
             "explicit_subtitle": None,
             "explicit_authors": [],
             "explicit_keywords": None,
+            "explicit_thumbnail": None,
         }
 
 
@@ -562,6 +567,7 @@ def analyze_notebooks(root_dir="notebooks"):
                 "title": title,
                 "description": notebook_data["explicit_description"] or "",
                 "tags": tags,
+                "thumbnail": notebook_data["explicit_thumbnail"] or "",
                 "full_path": str(file_path),
                 "folder": (
                     str(file_path.parent.relative_to(root_dir))
@@ -593,6 +599,7 @@ def export_metadata_for_plugin(notebook_tags, output_dir="notebooks"):
             "title": meta["title"],
             "description": meta.get("description", ""),
             "tags": meta["tags"],
+            "thumbnail": meta.get("thumbnail", ""),
             "has_explicit_tags": meta.get("has_explicit_tags", False),
             "folder": meta["folder"],
         }

--- a/notebooks/.gallery-metadata.json
+++ b/notebooks/.gallery-metadata.json
@@ -2,11 +2,7 @@
   "STAC/Data_Access_Tutorial": {
     "title": "Accessing Zarr Data",
     "description": "Explore how to access Data in Zarr format.",
-    "tags": [
-      "land",
-      "xarray",
-      "sentinel-2"
-    ],
+    "tags": ["land", "xarray", "sentinel-2"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "STAC"
@@ -14,11 +10,7 @@
   "STAC/STAC_EOPF_ZARR_SENTINEL": {
     "title": "STAC-Based Exploration and Visualization of Sentinel-2 and Sentinel-1 Data",
     "description": "Learn how to access Sentinel-2 and Sentinel-1 images via the EOPF STAC Catalog using pystac-client",
-    "tags": [
-      "land",
-      "stac",
-      "sentinel-1"
-    ],
+    "tags": ["land", "stac", "sentinel-1"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "STAC"
@@ -26,11 +18,7 @@
   "xarray_eopf_plugin/introduction": {
     "title": "Intoduction to the xarray EOPF backend",
     "description": "Access and explore analysis-ready and native EOPF Zarr data using xarray",
-    "tags": [
-      "land",
-      "xarray-eopf",
-      "sentinel-2"
-    ],
+    "tags": ["land", "xarray-eopf", "sentinel-2"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -38,11 +26,7 @@
   "xarray_eopf_plugin/sentinel_2_analysis": {
     "title": "xarray EOPF backend - Sentinel-2 Analysis Mode",
     "description": "Learn how to access Sentinel-2 products in analysis mode",
-    "tags": [
-      "land",
-      "xarray-eopf",
-      "sentinel-2"
-    ],
+    "tags": ["land", "xarray-eopf", "sentinel-2"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -50,11 +34,7 @@
   "xarray_eopf_plugin/sentinel_2_native": {
     "title": "xarray EOPF backend - Sentinel-2 Native mode",
     "description": "Learn how to access Sentinel-2 products in native mode",
-    "tags": [
-      "land",
-      "xarray-eopf",
-      "sentinel-2"
-    ],
+    "tags": ["land", "xarray-eopf", "sentinel-2"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -62,11 +42,7 @@
   "xarray_eopf_plugin/sentinel_3_native": {
     "title": "xarray EOPF backend - Sentinel-3 Native Mode",
     "description": "Learn how to access Sentinel-3 products in native mode",
-    "tags": [
-      "land",
-      "sentinel-3",
-      "xarray-eopf"
-    ],
+    "tags": ["land", "sentinel-3", "xarray-eopf"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -74,11 +50,7 @@
   "xarray_eopf_plugin/sentinel_1_native": {
     "title": "xarray EOPF backend - Sentinel-1 Native Mode",
     "description": "Learn how to access Sentinel-1 products in native mode",
-    "tags": [
-      "land",
-      "xarray-eopf",
-      "sentinel-1"
-    ],
+    "tags": ["land", "xarray-eopf", "sentinel-1"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -86,11 +58,7 @@
   "xarray_eopf_plugin/sentinel_3_analysis": {
     "title": "xarray EOPF backend - Sentinel-3 Analysis Mode",
     "description": "Learn how to access Sentinel-3 products in analysis mode",
-    "tags": [
-      "land",
-      "sentinel-3",
-      "xarray-eopf"
-    ],
+    "tags": ["land", "sentinel-3", "xarray-eopf"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -98,11 +66,7 @@
   "performance/sentinel_performance_zarr_safe_xcube": {
     "title": "EOPF zarr Performance Comparison - xcube",
     "description": "Compare the performance of the Sentinel EOPF zarr format to the SAFE format using the xcube readers.",
-    "tags": [
-      "sentinel-2",
-      "performance",
-      "xcube"
-    ],
+    "tags": ["sentinel-2", "performance", "xcube"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "performance"
@@ -110,10 +74,7 @@
   "performance/sentinel_performance_zarr_safe_direct": {
     "title": "EOPF zarr Performance Comparison - direct read",
     "description": "Compare the performance of the Sentinel EOPF zarr format to the SAFE format reading the files directly.",
-    "tags": [
-      "sentinel-2",
-      "performance"
-    ],
+    "tags": ["sentinel-2", "performance"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "performance"
@@ -121,12 +82,7 @@
   "Sentinel-2/eopf_openeo_stac_remote": {
     "title": "EOPF Zarr Data Access with openEO and STAC",
     "description": "Learn how to use the EOPF Zarr data through STAC and openEO",
-    "tags": [
-      "land",
-      "openeo",
-      "stac",
-      "sentinel-2"
-    ],
+    "tags": ["land", "openeo", "stac", "sentinel-2"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -134,10 +90,7 @@
   "Sentinel-2/Sentinel-2_L1C_data_access": {
     "title": "Sentinel-2 L1C Data Access",
     "description": "Demonstrate how to access Sentinel-2 L1C data in EOPF Zarr format",
-    "tags": [
-      "basic",
-      "sentinel-2"
-    ],
+    "tags": ["basic", "sentinel-2"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -145,11 +98,7 @@
   "Sentinel-2/Random_Forest_Land_Cover": {
     "title": "Random Forest Based Land-Cover Mapping with Sentinel-2",
     "description": "Demonstrate how to perform a basic land cover mapping using random forest and the Sentinel-2 data in EOPF Zarr format",
-    "tags": [
-      "land",
-      "sentinel-2",
-      "xcube"
-    ],
+    "tags": ["land", "sentinel-2", "xcube"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -157,11 +106,7 @@
   "Sentinel-2/sentinel-2_crop_type_classification_rule-based": {
     "title": "Sentinel-2 Crop-Type Classification",
     "description": "",
-    "tags": [
-      "land",
-      "xarray",
-      "sentinel-2"
-    ],
+    "tags": ["land", "xarray", "sentinel-2"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -169,11 +114,7 @@
   "Sentinel-2/NDVI_based_landslide_mapping": {
     "title": "NDVI-based approach to study Landslide areas",
     "description": "Streamlining Cloud-Based Processing with EOPF and Xarray",
-    "tags": [
-      "security",
-      "xarray",
-      "sentinel-2"
-    ],
+    "tags": ["security", "xarray", "sentinel-2"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -181,11 +122,7 @@
   "Sentinel-2/deforestation_monitoring_zarr": {
     "title": "Deforestation Monitoring using Sentinel 2 and xarray",
     "description": "Streamlining Cloud-Based Processing with EOPF and Xarray",
-    "tags": [
-      "security",
-      "xarray",
-      "sentinel-2"
-    ],
+    "tags": ["security", "xarray", "sentinel-2"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -193,11 +130,7 @@
   "Sentinel-2/parcel_delineation_sentinel": {
     "title": "Parcel delineation using Sentinel-2",
     "description": "Delineating agricultural parcels based on a neural network, using Sentinel-2 input data",
-    "tags": [
-      "land",
-      "xarray",
-      "sentinel-2"
-    ],
+    "tags": ["land", "xarray", "sentinel-2"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -205,12 +138,7 @@
   "Sentinel-2/eopf_openeo_stac": {
     "title": "EOPF Zarr Data Access with openEO and STAC",
     "description": "Learn how to use the EOPF Zarr data through STAC and openEO",
-    "tags": [
-      "land",
-      "openeo",
-      "stac",
-      "sentinel-2"
-    ],
+    "tags": ["land", "openeo", "stac", "sentinel-2"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -218,11 +146,7 @@
   "Sentinel-2/GDAL_explore_Zarr": {
     "title": "Explore EOPF Zarr Sentinel-2 files using GDAL",
     "description": "Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format",
-    "tags": [
-      "land",
-      "gdal",
-      "sentinel-2"
-    ],
+    "tags": ["land", "gdal", "sentinel-2"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -230,11 +154,7 @@
   "Sentinel-2/Sentinel-2_wildfire_mapping": {
     "title": "Wildfire Burn Severity Assessment Using Sentinel-2 L2A Data and dNBR",
     "description": "A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Ger\u00eas wildfire event (Portugal, July 2025).",
-    "tags": [
-      "stac",
-      "climate-change",
-      "sentinel-2"
-    ],
+    "tags": ["stac", "climate-change", "sentinel-2"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -242,11 +162,7 @@
   "Sentinel-2/oil_spill_index": {
     "title": "OSI - Oil Spill Index",
     "description": "Learn how to use the Oil Spill Index (OSI) to detect oil spills using Sentine-2 data.",
-    "tags": [
-      "sentinel 2",
-      "stac",
-      "marine"
-    ],
+    "tags": ["sentinel 2", "stac", "marine"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -254,11 +170,7 @@
   "Sentinel-2/Sentinel-2_NDSI_Snow_Mapping": {
     "title": "NDSI based snow mapping with Sentinel-2",
     "description": "Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format",
-    "tags": [
-      "climate-change",
-      "sentinel-2",
-      "xcube"
-    ],
+    "tags": ["climate-change", "sentinel-2", "xcube"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -266,11 +178,7 @@
   "Sentinel-2/oceanographic_wave_spectral_analysis": {
     "title": "Transforming workflow for oceanography study using Sentinel\u20112 data, from SAFE to Zarr",
     "description": "Computing wave spectra with 2D FFT & coherence in the EOPF framework",
-    "tags": [
-      "marine",
-      "xarray",
-      "sentinel-2"
-    ],
+    "tags": ["marine", "xarray", "sentinel-2"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -278,11 +186,7 @@
   "Sentinel-2/Potato_Field_Crop_Type": {
     "title": "NDVI Time-Series Analysis of Potato Fields",
     "description": "A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.",
-    "tags": [
-      "land",
-      "xarray",
-      "sentinel-2"
-    ],
+    "tags": ["land", "xarray", "sentinel-2"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -290,11 +194,7 @@
   "Sentinel-2/SAFE_Zarr_Metadata_Comparison_S2_L2A": {
     "title": "Zarr vs SAFE Metadata",
     "description": "Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)",
-    "tags": [
-      "land",
-      "gdal",
-      "sentinel-2"
-    ],
+    "tags": ["land", "gdal", "sentinel-2"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -302,11 +202,7 @@
   "Sentinel-2/water_level_timeseries": {
     "title": "Surface Water Level Monitoring with Sentinel-2",
     "description": "Timeseries of water covered area at Santa Giustina lake, Italy",
-    "tags": [
-      "xarray",
-      "climate-change",
-      "sentinel-2"
-    ],
+    "tags": ["xarray", "climate-change", "sentinel-2"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -314,10 +210,7 @@
   "Sentinel-2/Sentinel-2_L2A_data_access": {
     "title": "Sentinel-2 L2A Data Access",
     "description": "Demonstrate how to access Sentinel-2 L2A data in EOPF Zarr format",
-    "tags": [
-      "basic",
-      "sentinel-2"
-    ],
+    "tags": ["basic", "sentinel-2"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -325,11 +218,7 @@
   "Sentinel-2/Sentinel-2_snow_cover_fraction": {
     "title": "Analysing snow cover in the Alps using Sentinel-2",
     "description": "Learn how to use the EOPF Zarr data to analyse snow cover dynamics in the Alps with Sentinel-2 imagery.",
-    "tags": [
-      "land",
-      "stac",
-      "sentinel-2"
-    ],
+    "tags": ["land", "stac", "sentinel-2"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -337,11 +226,7 @@
   "Sentinel-2/Sentinel-2_L1C_MSI_Zarr_product_exploration": {
     "title": "Sentinel-2 L1C MSI Zarr Product Exploration",
     "description": "Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format",
-    "tags": [
-      "land",
-      "xarray",
-      "sentinel-2"
-    ],
+    "tags": ["land", "xarray", "sentinel-2"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -349,10 +234,7 @@
   "Sentinel-3/Sentinel-3_OLCI_L2_LFR_data_access": {
     "title": "Sentinel-3 OLCI L2 LFR Data Access",
     "description": "Demonstrate how to access Sentinel-3 OLCI L2 LFR data in EOPF Zarr format",
-    "tags": [
-      "sentinel-3",
-      "basic"
-    ],
+    "tags": ["sentinel-3", "basic"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -360,11 +242,7 @@
   "Sentinel-3/GDAL_Sentinel-3-OLCI-Level-1-EFR": {
     "title": "Open Sentinel-3-OLCI-Level-1-EFR Data with GDAL and eopfzarr",
     "description": "",
-    "tags": [
-      "sentinel-3",
-      "climate-change",
-      "gdal"
-    ],
+    "tags": ["sentinel-3", "climate-change", "gdal"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -372,10 +250,7 @@
   "Sentinel-3/Sentinel-3_SLSTR_L2_LST_data_access": {
     "title": "Sentinel-3 SLSTR L2 LST Data Access",
     "description": "Demonstrate how to access Sentinel-3 SLSTR L2 LST data in EOPF Zarr format",
-    "tags": [
-      "sentinel-3",
-      "basic"
-    ],
+    "tags": ["sentinel-3", "basic"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -383,11 +258,7 @@
   "Sentinel-3/Sentinel-3_Heatwave_Mapping": {
     "title": "Heatwave in Netherlands",
     "description": "Learn how to read, process and use Sentinel-3 Land Surface Temperature",
-    "tags": [
-      "sentinel-3",
-      "climate-change",
-      "xarray"
-    ],
+    "tags": ["sentinel-3", "climate-change", "xarray"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -395,11 +266,7 @@
   "Sentinel-3/GDAL_Sentinel-3_Multi-Product-Demo": {
     "title": "Sentinel-3 Multi-Product Demo with GDAL",
     "description": "Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver",
-    "tags": [
-      "sentinel-3",
-      "climate-change",
-      "gdal"
-    ],
+    "tags": ["sentinel-3", "climate-change", "gdal"],
     "thumbnail": "../static/ESA_EOPF_logo_2025_COLOR_ESA_blue_reduced.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -407,11 +274,7 @@
   "Sentinel-3/Regridding_Sentinel_3_SLSTR_LST": {
     "title": "Regridding Sentinel-3 SLSTR Data",
     "description": "Learn how to regridding Sentinel-3 SLSTR data",
-    "tags": [
-      "sentinel-3",
-      "climate-change",
-      "xarray"
-    ],
+    "tags": ["sentinel-3", "climate-change", "xarray"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -419,10 +282,7 @@
   "Sentinel-3/Sentinel-3_OLCI_L1_EFR_data_access": {
     "title": "Sentinel-3 OLCI L1 EFR Data Access",
     "description": "Demonstrate how to access Sentinel-3 OLCI L1 EFR data in EOPF Zarr format",
-    "tags": [
-      "sentinel-3",
-      "basic"
-    ],
+    "tags": ["sentinel-3", "basic"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -430,9 +290,7 @@
   "Dask/Dask_Intro": {
     "title": "Dask Intro",
     "description": "Explore how to connect to the dask gateway, spin up and scale a cluster and submit a simple workload.",
-    "tags": [
-      "dask"
-    ],
+    "tags": ["dask"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Dask"
@@ -440,10 +298,7 @@
   "Sentinel-1/GDAL_Sentinel-1_GCP_Geolocation": {
     "title": "Sentinel-1 GRD Geolocation with EOPFZARR Driver",
     "description": "Ground Control Point (GCP) based geolocation for Sentinel-1 GRD products using the EOPFZARR GDAL driver",
-    "tags": [
-      "sentinel-1",
-      "gdal"
-    ],
+    "tags": ["sentinel-1", "gdal"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -451,11 +306,7 @@
   "Sentinel-1/Sentinel-1_L1_GRD_Zarr_product_exploration": {
     "title": "Sentinel-1 GRD Zarr Product Exploration",
     "description": "Explore how to open, inspect the metadata and visualise Sentinel-1 GRD Zarr format",
-    "tags": [
-      "land",
-      "sentinel-1",
-      "xarray"
-    ],
+    "tags": ["land", "sentinel-1", "xarray"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -463,11 +314,7 @@
   "Sentinel-1/Sentinel-1_L2_OCN_Zarr_product_exploration": {
     "title": "Sentinel-1 L2 OCN Zarr Product Exploration",
     "description": "Explore how to open, visualise and use Sentinel-1 OCN products in EOPF Zarr format",
-    "tags": [
-      "marine",
-      "sentinel-1",
-      "xarray"
-    ],
+    "tags": ["marine", "sentinel-1", "xarray"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -475,11 +322,7 @@
   "Sentinel-1/Sentinel-1_Soil_moisture": {
     "title": "Sentinel 1 Surface Soil Moisture (SSM)",
     "description": "Learn how to compute surface soil moisture from Sentinel-1 data",
-    "tags": [
-      "land",
-      "sentinel-1",
-      "xarray"
-    ],
+    "tags": ["land", "sentinel-1", "xarray"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -487,11 +330,7 @@
   "Sentinel-1/Sentinel-1_L1_SLC_Zarr_product_exploration": {
     "title": "Sentinel-1 SLC Zarr Product Exploration",
     "description": "Explore how to open, inspect the metadata and process Sentinel-1 Single Look Complex (SLC) Zarr format",
-    "tags": [
-      "land",
-      "sentinel-1",
-      "xarray"
-    ],
+    "tags": ["land", "sentinel-1", "xarray"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -499,10 +338,7 @@
   "Sentinel-1/GDAL_Sentinel-1_SLC_Burst_Selection": {
     "title": "Sentinel-1 SLC Burst Selection with EOPFZARR GDAL Driver",
     "description": "Directly access individual bursts from Sentinel-1 SLC products using the BURST open option",
-    "tags": [
-      "sentinel-1",
-      "gdal"
-    ],
+    "tags": ["sentinel-1", "gdal"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -510,11 +346,7 @@
   "Sentinel-1/radar_vegetation_index": {
     "title": "Radar Vegetation Index",
     "description": "Monitor vegetation crop growth using Sentinel-1 GRD data",
-    "tags": [
-      "land",
-      "sentinel-1",
-      "xarray"
-    ],
+    "tags": ["land", "sentinel-1", "xarray"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -522,11 +354,7 @@
   "xcube_eopf_plugin/introduction": {
     "title": "Introduction to the xcube EOPF Data Store",
     "description": "Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.",
-    "tags": [
-      "land",
-      "sentinel-2",
-      "xcube"
-    ],
+    "tags": ["land", "sentinel-2", "xcube"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xcube_eopf_plugin"
@@ -534,11 +362,7 @@
   "xcube_eopf_plugin/sentinel_3": {
     "title": "Building Sentinel-3 Data Cubes with xcube EOPF Data Store",
     "description": "Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.",
-    "tags": [
-      "land",
-      "sentinel-3",
-      "xcube"
-    ],
+    "tags": ["land", "sentinel-3", "xcube"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xcube_eopf_plugin"
@@ -546,11 +370,7 @@
   "xcube_eopf_plugin/sentinel_2": {
     "title": "Building Sentinel-2 Data Cubes with xcube EOPF Data Store",
     "description": "Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.",
-    "tags": [
-      "land",
-      "sentinel-2",
-      "xcube"
-    ],
+    "tags": ["land", "sentinel-2", "xcube"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xcube_eopf_plugin"

--- a/notebooks/.gallery-metadata.json
+++ b/notebooks/.gallery-metadata.json
@@ -2,287 +2,556 @@
   "STAC/Data_Access_Tutorial": {
     "title": "Accessing Zarr Data",
     "description": "Explore how to access Data in Zarr format.",
-    "tags": ["land", "xarray", "sentinel-2"],
+    "tags": [
+      "sentinel-2",
+      "xarray",
+      "land"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "STAC"
   },
   "STAC/STAC_EOPF_ZARR_SENTINEL": {
     "title": "STAC-Based Exploration and Visualization of Sentinel-2 and Sentinel-1 Data",
     "description": "Learn how to access Sentinel-2 and Sentinel-1 images via the EOPF STAC Catalog using pystac-client",
-    "tags": ["land", "stac", "sentinel-1"],
+    "tags": [
+      "stac",
+      "land",
+      "sentinel-1"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "STAC"
   },
   "xarray_eopf_plugin/introduction": {
     "title": "Intoduction to the xarray EOPF backend",
-    "description": "",
-    "tags": ["land", "xarray-eopf", "sentinel-2"],
+    "description": "Access and explore analysis-ready and native EOPF Zarr data using xarray",
+    "tags": [
+      "sentinel-2",
+      "xarray-eopf",
+      "land"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
+    "has_explicit_tags": true,
+    "folder": "xarray_eopf_plugin"
+  },
+  "xarray_eopf_plugin/sentinel_2_analysis": {
+    "title": "xarray EOPF backend - Sentinel-2 Analysis Mode",
+    "description": "Learn how to access Sentinel-2 products in analysis mode",
+    "tags": [
+      "sentinel-2",
+      "xarray-eopf",
+      "land"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
+    "has_explicit_tags": true,
+    "folder": "xarray_eopf_plugin"
+  },
+  "xarray_eopf_plugin/sentinel_2_native": {
+    "title": "xarray EOPF backend - Sentinel-2 Native mode",
+    "description": "Learn how to access Sentinel-2 products in native mode",
+    "tags": [
+      "sentinel-2",
+      "xarray-eopf",
+      "land"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
+    "has_explicit_tags": true,
+    "folder": "xarray_eopf_plugin"
+  },
+  "xarray_eopf_plugin/sentinel_3_native": {
+    "title": "xarray EOPF backend - Sentinel-3 Native Mode",
+    "description": "Learn how to access Sentinel-3 products in native mode",
+    "tags": [
+      "sentinel-3",
+      "xarray-eopf",
+      "land"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
+    "has_explicit_tags": true,
+    "folder": "xarray_eopf_plugin"
+  },
+  "xarray_eopf_plugin/sentinel_1_native": {
+    "title": "xarray EOPF backend - Sentinel-1 Native Mode",
+    "description": "Learn how to access Sentinel-1 products in native mode",
+    "tags": [
+      "xarray-eopf",
+      "land",
+      "sentinel-1"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
+    "has_explicit_tags": true,
+    "folder": "xarray_eopf_plugin"
+  },
+  "xarray_eopf_plugin/sentinel_3_analysis": {
+    "title": "xarray EOPF backend - Sentinel-3 Analysis Mode",
+    "description": "Learn how to access Sentinel-3 products in analysis mode",
+    "tags": [
+      "sentinel-3",
+      "xarray-eopf",
+      "land"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
   },
   "performance/sentinel_performance_zarr_safe_xcube": {
     "title": "EOPF zarr Performance Comparison - xcube",
     "description": "Compare the performance of the Sentinel EOPF zarr format to the SAFE format using the xcube readers.",
-    "tags": ["xcube", "sentinel-2", "performance"],
+    "tags": [
+      "sentinel-2",
+      "xcube",
+      "performance"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "performance"
   },
   "performance/sentinel_performance_zarr_safe_direct": {
     "title": "EOPF zarr Performance Comparison - direct read",
     "description": "Compare the performance of the Sentinel EOPF zarr format to the SAFE format reading the files directly.",
-    "tags": ["sentinel-2", "performance"],
+    "tags": [
+      "sentinel-2",
+      "performance"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "performance"
   },
   "Sentinel-2/eopf_openeo_stac_remote": {
     "title": "EOPF Zarr Data Access with openEO and STAC",
     "description": "Learn how to use the EOPF Zarr data through STAC and openEO",
-    "tags": ["land", "stac", "openeo", "sentinel-2"],
+    "tags": [
+      "openeo",
+      "stac",
+      "land",
+      "sentinel-2"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/Sentinel-2_L1C_data_access": {
     "title": "Sentinel-2 L1C Data Access",
     "description": "Demonstrate how to access Sentinel-2 L1C data in EOPF Zarr format",
-    "tags": ["basic", "sentinel-2"],
+    "tags": [
+      "sentinel-2",
+      "basic"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/Random_Forest_Land_Cover": {
     "title": "Random Forest Based Land-Cover Mapping with Sentinel-2",
     "description": "Demonstrate how to perform a basic land cover mapping using random forest and the Sentinel-2 data in EOPF Zarr format",
-    "tags": ["xcube", "land", "sentinel-2"],
+    "tags": [
+      "sentinel-2",
+      "xcube",
+      "land"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/sentinel-2_crop_type_classification_rule-based": {
     "title": "Sentinel-2 Crop-Type Classification",
     "description": "",
-    "tags": ["land", "xarray", "sentinel-2"],
+    "tags": [
+      "sentinel-2",
+      "xarray",
+      "land"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/NDVI_based_landslide_mapping": {
     "title": "NDVI-based approach to study Landslide areas",
     "description": "Streamlining Cloud-Based Processing with EOPF and Xarray",
-    "tags": ["security", "xarray", "sentinel-2"],
+    "tags": [
+      "security",
+      "sentinel-2",
+      "xarray"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/deforestation_monitoring_zarr": {
     "title": "Deforestation Monitoring using Sentinel 2 and xarray",
     "description": "Streamlining Cloud-Based Processing with EOPF and Xarray",
-    "tags": ["security", "xarray", "sentinel-2"],
+    "tags": [
+      "security",
+      "sentinel-2",
+      "xarray"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/parcel_delineation_sentinel": {
     "title": "Parcel delineation using Sentinel-2",
     "description": "Delineating agricultural parcels based on a neural network, using Sentinel-2 input data",
-    "tags": ["land", "xarray", "sentinel-2"],
+    "tags": [
+      "sentinel-2",
+      "xarray",
+      "land"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/eopf_openeo_stac": {
     "title": "EOPF Zarr Data Access with openEO and STAC",
     "description": "Learn how to use the EOPF Zarr data through STAC and openEO",
-    "tags": ["land", "stac", "openeo", "sentinel-2"],
+    "tags": [
+      "openeo",
+      "stac",
+      "land",
+      "sentinel-2"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/GDAL_explore_Zarr": {
     "title": "Explore EOPF Zarr Sentinel-2 files using GDAL",
     "description": "Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format",
-    "tags": ["gdal", "land", "sentinel-2"],
+    "tags": [
+      "sentinel-2",
+      "land",
+      "gdal"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/Sentinel-2_wildfire_mapping": {
     "title": "Wildfire Burn Severity Assessment Using Sentinel-2 L2A Data and dNBR",
     "description": "A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Ger\u00eas wildfire event (Portugal, July 2025).",
-    "tags": ["stac", "climate-change", "sentinel-2"],
+    "tags": [
+      "climate-change",
+      "sentinel-2",
+      "stac"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/oil_spill_index": {
     "title": "OSI - Oil Spill Index",
     "description": "Learn how to use the Oil Spill Index (OSI) to detect oil spills using Sentine-2 data.",
-    "tags": ["marine", "sentinel 2", "stac"],
+    "tags": [
+      "sentinel 2",
+      "marine",
+      "stac"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/Sentinel-2_NDSI_Snow_Mapping": {
     "title": "NDSI based snow mapping with Sentinel-2",
     "description": "Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format",
-    "tags": ["xcube", "climate-change", "sentinel-2"],
+    "tags": [
+      "climate-change",
+      "sentinel-2",
+      "xcube"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/oceanographic_wave_spectral_analysis": {
     "title": "Transforming workflow for oceanography study using Sentinel\u20112 data, from SAFE to Zarr",
     "description": "Computing wave spectra with 2D FFT & coherence in the EOPF framework",
-    "tags": ["marine", "xarray", "sentinel-2"],
+    "tags": [
+      "marine",
+      "xarray",
+      "sentinel-2"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/Potato_Field_Crop_Type": {
     "title": "NDVI Time-Series Analysis of Potato Fields",
     "description": "A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.",
-    "tags": ["land", "xarray", "sentinel-2"],
+    "tags": [
+      "sentinel-2",
+      "xarray",
+      "land"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/SAFE_Zarr_Metadata_Comparison_S2_L2A": {
     "title": "Zarr vs SAFE Metadata",
     "description": "Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)",
-    "tags": ["gdal", "land", "sentinel-2"],
+    "tags": [
+      "sentinel-2",
+      "land",
+      "gdal"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/water_level_timeseries": {
     "title": "Surface Water Level Monitoring with Sentinel-2",
     "description": "Timeseries of water covered area at Santa Giustina lake, Italy",
-    "tags": ["xarray", "climate-change", "sentinel-2"],
+    "tags": [
+      "climate-change",
+      "sentinel-2",
+      "xarray"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/Sentinel-2_L2A_data_access": {
     "title": "Sentinel-2 L2A Data Access",
     "description": "Demonstrate how to access Sentinel-2 L2A data in EOPF Zarr format",
-    "tags": ["basic", "sentinel-2"],
+    "tags": [
+      "sentinel-2",
+      "basic"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/Sentinel-2_snow_cover_fraction": {
     "title": "Analysing snow cover in the Alps using Sentinel-2",
     "description": "Learn how to use the EOPF Zarr data to analyse snow cover dynamics in the Alps with Sentinel-2 imagery.",
-    "tags": ["stac", "land", "sentinel-2"],
+    "tags": [
+      "sentinel-2",
+      "stac",
+      "land"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-2/Sentinel-2_L1C_MSI_Zarr_product_exploration": {
     "title": "Sentinel-2 L1C MSI Zarr Product Exploration",
     "description": "Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format",
-    "tags": ["land", "xarray", "sentinel-2"],
+    "tags": [
+      "sentinel-2",
+      "xarray",
+      "land"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
   },
   "Sentinel-3/Sentinel-3_OLCI_L2_LFR_data_access": {
     "title": "Sentinel-3 OLCI L2 LFR Data Access",
     "description": "Demonstrate how to access Sentinel-3 OLCI L2 LFR data in EOPF Zarr format",
-    "tags": ["basic", "sentinel-3"],
+    "tags": [
+      "sentinel-3",
+      "basic"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
   },
   "Sentinel-3/GDAL_Sentinel-3-OLCI-Level-1-EFR": {
     "title": "Open Sentinel-3-OLCI-Level-1-EFR Data with GDAL and eopfzarr",
     "description": "",
-    "tags": ["climate-change", "sentinel-3", "gdal"],
+    "tags": [
+      "climate-change",
+      "sentinel-3",
+      "gdal"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
   },
   "Sentinel-3/Sentinel-3_SLSTR_L2_LST_data_access": {
     "title": "Sentinel-3 SLSTR L2 LST Data Access",
     "description": "Demonstrate how to access Sentinel-3 SLSTR L2 LST data in EOPF Zarr format",
-    "tags": ["basic", "sentinel-3"],
+    "tags": [
+      "sentinel-3",
+      "basic"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
   },
   "Sentinel-3/Sentinel-3_Heatwave_Mapping": {
     "title": "Heatwave in Netherlands",
     "description": "Learn how to read, process and use Sentinel-3 Land Surface Temperature",
-    "tags": ["climate-change", "xarray", "sentinel-3"],
+    "tags": [
+      "climate-change",
+      "sentinel-3",
+      "xarray"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
   },
   "Sentinel-3/GDAL_Sentinel-3_Multi-Product-Demo": {
     "title": "Sentinel-3 Multi-Product Demo with GDAL",
     "description": "Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver",
-    "tags": ["climate-change", "sentinel-3", "gdal"],
+    "tags": [
+      "climate-change",
+      "sentinel-3",
+      "gdal"
+    ],
+    "thumbnail": "../static/ESA_EOPF_logo_2025_COLOR_ESA_blue_reduced.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
   },
   "Sentinel-3/Regridding_Sentinel_3_SLSTR_LST": {
     "title": "Regridding Sentinel-3 SLSTR Data",
     "description": "Learn how to regridding Sentinel-3 SLSTR data",
-    "tags": ["climate-change", "xarray", "sentinel-3"],
+    "tags": [
+      "climate-change",
+      "sentinel-3",
+      "xarray"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
   },
   "Sentinel-3/Sentinel-3_OLCI_L1_EFR_data_access": {
     "title": "Sentinel-3 OLCI L1 EFR Data Access",
     "description": "Demonstrate how to access Sentinel-3 OLCI L1 EFR data in EOPF Zarr format",
-    "tags": ["basic", "sentinel-3"],
+    "tags": [
+      "sentinel-3",
+      "basic"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
   },
   "Dask/Dask_Intro": {
     "title": "Dask Intro",
     "description": "Explore how to connect to the dask gateway, spin up and scale a cluster and submit a simple workload.",
-    "tags": ["dask"],
+    "tags": [
+      "dask"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Dask"
   },
   "Sentinel-1/GDAL_Sentinel-1_GCP_Geolocation": {
     "title": "Sentinel-1 GRD Geolocation with EOPFZARR Driver",
     "description": "Ground Control Point (GCP) based geolocation for Sentinel-1 GRD products using the EOPFZARR GDAL driver",
-    "tags": ["sentinel-1", "gdal"],
+    "tags": [
+      "gdal",
+      "sentinel-1"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
   },
   "Sentinel-1/Sentinel-1_L1_GRD_Zarr_product_exploration": {
     "title": "Sentinel-1 GRD Zarr Product Exploration",
     "description": "Explore how to open, inspect the metadata and visualise Sentinel-1 GRD Zarr format",
-    "tags": ["land", "xarray", "sentinel-1"],
+    "tags": [
+      "xarray",
+      "land",
+      "sentinel-1"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
   },
   "Sentinel-1/Sentinel-1_L2_OCN_Zarr_product_exploration": {
     "title": "Sentinel-1 L2 OCN Zarr Product Exploration",
     "description": "Explore how to open, visualise and use Sentinel-1 OCN products in EOPF Zarr format",
-    "tags": ["marine", "xarray", "sentinel-1"],
+    "tags": [
+      "marine",
+      "xarray",
+      "sentinel-1"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
   },
   "Sentinel-1/Sentinel-1_Soil_moisture": {
     "title": "Sentinel 1 Surface Soil Moisture (SSM)",
     "description": "Learn how to compute surface soil moisture from Sentinel-1 data",
-    "tags": ["land", "xarray", "sentinel-1"],
+    "tags": [
+      "xarray",
+      "land",
+      "sentinel-1"
+    ],
+    "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
   },
   "Sentinel-1/Sentinel-1_L1_SLC_Zarr_product_exploration": {
     "title": "Sentinel-1 SLC Zarr Product Exploration",
     "description": "Explore how to open, inspect the metadata and process Sentinel-1 Single Look Complex (SLC) Zarr format",
-    "tags": ["land", "xarray", "sentinel-1"],
+    "tags": [
+      "xarray",
+      "land",
+      "sentinel-1"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
   },
   "Sentinel-1/GDAL_Sentinel-1_SLC_Burst_Selection": {
     "title": "Sentinel-1 SLC Burst Selection with EOPFZARR GDAL Driver",
     "description": "Directly access individual bursts from Sentinel-1 SLC products using the BURST open option",
-    "tags": ["sentinel-1", "gdal"],
+    "tags": [
+      "gdal",
+      "sentinel-1"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
   },
   "Sentinel-1/radar_vegetation_index": {
     "title": "Radar Vegetation Index",
     "description": "Monitor vegetation crop growth using Sentinel-1 GRD data",
-    "tags": ["land", "xarray", "sentinel-1"],
+    "tags": [
+      "xarray",
+      "land",
+      "sentinel-1"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
   },
-  "xcube_eopf_plugin/xcube_eopf_sen2": {
-    "title": "Building Sentinel-2 Data Cubes with xcube EOPF",
-    "description": "From Multiple EOPF Zarr Tiles to Analysis-Ready Data Cubes (ARDCs)",
-    "tags": ["xcube", "land", "sentinel-2"],
+  "xcube_eopf_plugin/introduction": {
+    "title": "Introduction to the xcube EOPF Data Store",
+    "description": "Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.",
+    "tags": [
+      "sentinel-2",
+      "xcube",
+      "land"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xcube_eopf_plugin"
   },
-  "xcube_eopf_plugin/xcube_eopf_sen3": {
-    "title": "Building Sentinel-3 Data Cubes with xcube EOPF",
-    "description": "From Multiple EOPF Zarr Tiles to Analysis-Ready Data Cubes (ARDCs)",
-    "tags": ["xcube", "climate-change", "sentinel-3"],
+  "xcube_eopf_plugin/sentinel_3": {
+    "title": "Building Sentinel-3 Data Cubes with xcube EOPF Data Store",
+    "description": "Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.",
+    "tags": [
+      "sentinel-3",
+      "xcube",
+      "land"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
+    "has_explicit_tags": true,
+    "folder": "xcube_eopf_plugin"
+  },
+  "xcube_eopf_plugin/sentinel_2": {
+    "title": "Building Sentinel-2 Data Cubes with xcube EOPF Data Store",
+    "description": "Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.",
+    "tags": [
+      "sentinel-2",
+      "xcube",
+      "land"
+    ],
+    "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xcube_eopf_plugin"
   }

--- a/notebooks/.gallery-metadata.json
+++ b/notebooks/.gallery-metadata.json
@@ -2,7 +2,11 @@
   "STAC/Data_Access_Tutorial": {
     "title": "Accessing Zarr Data",
     "description": "Explore how to access Data in Zarr format.",
-    "tags": ["sentinel-2", "xarray", "land"],
+    "tags": [
+      "land",
+      "xarray",
+      "sentinel-2"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "STAC"
@@ -10,7 +14,11 @@
   "STAC/STAC_EOPF_ZARR_SENTINEL": {
     "title": "STAC-Based Exploration and Visualization of Sentinel-2 and Sentinel-1 Data",
     "description": "Learn how to access Sentinel-2 and Sentinel-1 images via the EOPF STAC Catalog using pystac-client",
-    "tags": ["stac", "land", "sentinel-1"],
+    "tags": [
+      "land",
+      "stac",
+      "sentinel-1"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "STAC"
@@ -18,7 +26,11 @@
   "xarray_eopf_plugin/introduction": {
     "title": "Intoduction to the xarray EOPF backend",
     "description": "Access and explore analysis-ready and native EOPF Zarr data using xarray",
-    "tags": ["sentinel-2", "xarray-eopf", "land"],
+    "tags": [
+      "land",
+      "xarray-eopf",
+      "sentinel-2"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -26,7 +38,11 @@
   "xarray_eopf_plugin/sentinel_2_analysis": {
     "title": "xarray EOPF backend - Sentinel-2 Analysis Mode",
     "description": "Learn how to access Sentinel-2 products in analysis mode",
-    "tags": ["sentinel-2", "xarray-eopf", "land"],
+    "tags": [
+      "land",
+      "xarray-eopf",
+      "sentinel-2"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -34,7 +50,11 @@
   "xarray_eopf_plugin/sentinel_2_native": {
     "title": "xarray EOPF backend - Sentinel-2 Native mode",
     "description": "Learn how to access Sentinel-2 products in native mode",
-    "tags": ["sentinel-2", "xarray-eopf", "land"],
+    "tags": [
+      "land",
+      "xarray-eopf",
+      "sentinel-2"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -42,7 +62,11 @@
   "xarray_eopf_plugin/sentinel_3_native": {
     "title": "xarray EOPF backend - Sentinel-3 Native Mode",
     "description": "Learn how to access Sentinel-3 products in native mode",
-    "tags": ["sentinel-3", "xarray-eopf", "land"],
+    "tags": [
+      "land",
+      "sentinel-3",
+      "xarray-eopf"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -50,7 +74,11 @@
   "xarray_eopf_plugin/sentinel_1_native": {
     "title": "xarray EOPF backend - Sentinel-1 Native Mode",
     "description": "Learn how to access Sentinel-1 products in native mode",
-    "tags": ["xarray-eopf", "land", "sentinel-1"],
+    "tags": [
+      "land",
+      "xarray-eopf",
+      "sentinel-1"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -58,7 +86,11 @@
   "xarray_eopf_plugin/sentinel_3_analysis": {
     "title": "xarray EOPF backend - Sentinel-3 Analysis Mode",
     "description": "Learn how to access Sentinel-3 products in analysis mode",
-    "tags": ["sentinel-3", "xarray-eopf", "land"],
+    "tags": [
+      "land",
+      "sentinel-3",
+      "xarray-eopf"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -66,7 +98,11 @@
   "performance/sentinel_performance_zarr_safe_xcube": {
     "title": "EOPF zarr Performance Comparison - xcube",
     "description": "Compare the performance of the Sentinel EOPF zarr format to the SAFE format using the xcube readers.",
-    "tags": ["sentinel-2", "xcube", "performance"],
+    "tags": [
+      "sentinel-2",
+      "performance",
+      "xcube"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "performance"
@@ -74,7 +110,10 @@
   "performance/sentinel_performance_zarr_safe_direct": {
     "title": "EOPF zarr Performance Comparison - direct read",
     "description": "Compare the performance of the Sentinel EOPF zarr format to the SAFE format reading the files directly.",
-    "tags": ["sentinel-2", "performance"],
+    "tags": [
+      "sentinel-2",
+      "performance"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "performance"
@@ -82,7 +121,12 @@
   "Sentinel-2/eopf_openeo_stac_remote": {
     "title": "EOPF Zarr Data Access with openEO and STAC",
     "description": "Learn how to use the EOPF Zarr data through STAC and openEO",
-    "tags": ["openeo", "stac", "land", "sentinel-2"],
+    "tags": [
+      "land",
+      "openeo",
+      "stac",
+      "sentinel-2"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -90,7 +134,10 @@
   "Sentinel-2/Sentinel-2_L1C_data_access": {
     "title": "Sentinel-2 L1C Data Access",
     "description": "Demonstrate how to access Sentinel-2 L1C data in EOPF Zarr format",
-    "tags": ["sentinel-2", "basic"],
+    "tags": [
+      "basic",
+      "sentinel-2"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -98,7 +145,11 @@
   "Sentinel-2/Random_Forest_Land_Cover": {
     "title": "Random Forest Based Land-Cover Mapping with Sentinel-2",
     "description": "Demonstrate how to perform a basic land cover mapping using random forest and the Sentinel-2 data in EOPF Zarr format",
-    "tags": ["sentinel-2", "xcube", "land"],
+    "tags": [
+      "land",
+      "sentinel-2",
+      "xcube"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -106,7 +157,11 @@
   "Sentinel-2/sentinel-2_crop_type_classification_rule-based": {
     "title": "Sentinel-2 Crop-Type Classification",
     "description": "",
-    "tags": ["sentinel-2", "xarray", "land"],
+    "tags": [
+      "land",
+      "xarray",
+      "sentinel-2"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -114,7 +169,11 @@
   "Sentinel-2/NDVI_based_landslide_mapping": {
     "title": "NDVI-based approach to study Landslide areas",
     "description": "Streamlining Cloud-Based Processing with EOPF and Xarray",
-    "tags": ["security", "sentinel-2", "xarray"],
+    "tags": [
+      "security",
+      "xarray",
+      "sentinel-2"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -122,7 +181,11 @@
   "Sentinel-2/deforestation_monitoring_zarr": {
     "title": "Deforestation Monitoring using Sentinel 2 and xarray",
     "description": "Streamlining Cloud-Based Processing with EOPF and Xarray",
-    "tags": ["security", "sentinel-2", "xarray"],
+    "tags": [
+      "security",
+      "xarray",
+      "sentinel-2"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -130,7 +193,11 @@
   "Sentinel-2/parcel_delineation_sentinel": {
     "title": "Parcel delineation using Sentinel-2",
     "description": "Delineating agricultural parcels based on a neural network, using Sentinel-2 input data",
-    "tags": ["sentinel-2", "xarray", "land"],
+    "tags": [
+      "land",
+      "xarray",
+      "sentinel-2"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -138,7 +205,12 @@
   "Sentinel-2/eopf_openeo_stac": {
     "title": "EOPF Zarr Data Access with openEO and STAC",
     "description": "Learn how to use the EOPF Zarr data through STAC and openEO",
-    "tags": ["openeo", "stac", "land", "sentinel-2"],
+    "tags": [
+      "land",
+      "openeo",
+      "stac",
+      "sentinel-2"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -146,7 +218,11 @@
   "Sentinel-2/GDAL_explore_Zarr": {
     "title": "Explore EOPF Zarr Sentinel-2 files using GDAL",
     "description": "Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format",
-    "tags": ["sentinel-2", "land", "gdal"],
+    "tags": [
+      "land",
+      "gdal",
+      "sentinel-2"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -154,7 +230,11 @@
   "Sentinel-2/Sentinel-2_wildfire_mapping": {
     "title": "Wildfire Burn Severity Assessment Using Sentinel-2 L2A Data and dNBR",
     "description": "A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Ger\u00eas wildfire event (Portugal, July 2025).",
-    "tags": ["climate-change", "sentinel-2", "stac"],
+    "tags": [
+      "stac",
+      "climate-change",
+      "sentinel-2"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -162,7 +242,11 @@
   "Sentinel-2/oil_spill_index": {
     "title": "OSI - Oil Spill Index",
     "description": "Learn how to use the Oil Spill Index (OSI) to detect oil spills using Sentine-2 data.",
-    "tags": ["sentinel 2", "marine", "stac"],
+    "tags": [
+      "sentinel 2",
+      "stac",
+      "marine"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -170,7 +254,11 @@
   "Sentinel-2/Sentinel-2_NDSI_Snow_Mapping": {
     "title": "NDSI based snow mapping with Sentinel-2",
     "description": "Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format",
-    "tags": ["climate-change", "sentinel-2", "xcube"],
+    "tags": [
+      "climate-change",
+      "sentinel-2",
+      "xcube"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -178,7 +266,11 @@
   "Sentinel-2/oceanographic_wave_spectral_analysis": {
     "title": "Transforming workflow for oceanography study using Sentinel\u20112 data, from SAFE to Zarr",
     "description": "Computing wave spectra with 2D FFT & coherence in the EOPF framework",
-    "tags": ["marine", "xarray", "sentinel-2"],
+    "tags": [
+      "marine",
+      "xarray",
+      "sentinel-2"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -186,7 +278,11 @@
   "Sentinel-2/Potato_Field_Crop_Type": {
     "title": "NDVI Time-Series Analysis of Potato Fields",
     "description": "A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.",
-    "tags": ["sentinel-2", "xarray", "land"],
+    "tags": [
+      "land",
+      "xarray",
+      "sentinel-2"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -194,7 +290,11 @@
   "Sentinel-2/SAFE_Zarr_Metadata_Comparison_S2_L2A": {
     "title": "Zarr vs SAFE Metadata",
     "description": "Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)",
-    "tags": ["sentinel-2", "land", "gdal"],
+    "tags": [
+      "land",
+      "gdal",
+      "sentinel-2"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -202,7 +302,11 @@
   "Sentinel-2/water_level_timeseries": {
     "title": "Surface Water Level Monitoring with Sentinel-2",
     "description": "Timeseries of water covered area at Santa Giustina lake, Italy",
-    "tags": ["climate-change", "sentinel-2", "xarray"],
+    "tags": [
+      "xarray",
+      "climate-change",
+      "sentinel-2"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -210,7 +314,10 @@
   "Sentinel-2/Sentinel-2_L2A_data_access": {
     "title": "Sentinel-2 L2A Data Access",
     "description": "Demonstrate how to access Sentinel-2 L2A data in EOPF Zarr format",
-    "tags": ["sentinel-2", "basic"],
+    "tags": [
+      "basic",
+      "sentinel-2"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -218,7 +325,11 @@
   "Sentinel-2/Sentinel-2_snow_cover_fraction": {
     "title": "Analysing snow cover in the Alps using Sentinel-2",
     "description": "Learn how to use the EOPF Zarr data to analyse snow cover dynamics in the Alps with Sentinel-2 imagery.",
-    "tags": ["sentinel-2", "stac", "land"],
+    "tags": [
+      "land",
+      "stac",
+      "sentinel-2"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -226,7 +337,11 @@
   "Sentinel-2/Sentinel-2_L1C_MSI_Zarr_product_exploration": {
     "title": "Sentinel-2 L1C MSI Zarr Product Exploration",
     "description": "Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format",
-    "tags": ["sentinel-2", "xarray", "land"],
+    "tags": [
+      "land",
+      "xarray",
+      "sentinel-2"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -234,7 +349,10 @@
   "Sentinel-3/Sentinel-3_OLCI_L2_LFR_data_access": {
     "title": "Sentinel-3 OLCI L2 LFR Data Access",
     "description": "Demonstrate how to access Sentinel-3 OLCI L2 LFR data in EOPF Zarr format",
-    "tags": ["sentinel-3", "basic"],
+    "tags": [
+      "sentinel-3",
+      "basic"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -242,7 +360,11 @@
   "Sentinel-3/GDAL_Sentinel-3-OLCI-Level-1-EFR": {
     "title": "Open Sentinel-3-OLCI-Level-1-EFR Data with GDAL and eopfzarr",
     "description": "",
-    "tags": ["climate-change", "sentinel-3", "gdal"],
+    "tags": [
+      "sentinel-3",
+      "climate-change",
+      "gdal"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -250,7 +372,10 @@
   "Sentinel-3/Sentinel-3_SLSTR_L2_LST_data_access": {
     "title": "Sentinel-3 SLSTR L2 LST Data Access",
     "description": "Demonstrate how to access Sentinel-3 SLSTR L2 LST data in EOPF Zarr format",
-    "tags": ["sentinel-3", "basic"],
+    "tags": [
+      "sentinel-3",
+      "basic"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -258,7 +383,11 @@
   "Sentinel-3/Sentinel-3_Heatwave_Mapping": {
     "title": "Heatwave in Netherlands",
     "description": "Learn how to read, process and use Sentinel-3 Land Surface Temperature",
-    "tags": ["climate-change", "sentinel-3", "xarray"],
+    "tags": [
+      "sentinel-3",
+      "climate-change",
+      "xarray"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -266,7 +395,11 @@
   "Sentinel-3/GDAL_Sentinel-3_Multi-Product-Demo": {
     "title": "Sentinel-3 Multi-Product Demo with GDAL",
     "description": "Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver",
-    "tags": ["climate-change", "sentinel-3", "gdal"],
+    "tags": [
+      "sentinel-3",
+      "climate-change",
+      "gdal"
+    ],
     "thumbnail": "../static/ESA_EOPF_logo_2025_COLOR_ESA_blue_reduced.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -274,7 +407,11 @@
   "Sentinel-3/Regridding_Sentinel_3_SLSTR_LST": {
     "title": "Regridding Sentinel-3 SLSTR Data",
     "description": "Learn how to regridding Sentinel-3 SLSTR data",
-    "tags": ["climate-change", "sentinel-3", "xarray"],
+    "tags": [
+      "sentinel-3",
+      "climate-change",
+      "xarray"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -282,7 +419,10 @@
   "Sentinel-3/Sentinel-3_OLCI_L1_EFR_data_access": {
     "title": "Sentinel-3 OLCI L1 EFR Data Access",
     "description": "Demonstrate how to access Sentinel-3 OLCI L1 EFR data in EOPF Zarr format",
-    "tags": ["sentinel-3", "basic"],
+    "tags": [
+      "sentinel-3",
+      "basic"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -290,7 +430,9 @@
   "Dask/Dask_Intro": {
     "title": "Dask Intro",
     "description": "Explore how to connect to the dask gateway, spin up and scale a cluster and submit a simple workload.",
-    "tags": ["dask"],
+    "tags": [
+      "dask"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Dask"
@@ -298,7 +440,10 @@
   "Sentinel-1/GDAL_Sentinel-1_GCP_Geolocation": {
     "title": "Sentinel-1 GRD Geolocation with EOPFZARR Driver",
     "description": "Ground Control Point (GCP) based geolocation for Sentinel-1 GRD products using the EOPFZARR GDAL driver",
-    "tags": ["gdal", "sentinel-1"],
+    "tags": [
+      "sentinel-1",
+      "gdal"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -306,7 +451,11 @@
   "Sentinel-1/Sentinel-1_L1_GRD_Zarr_product_exploration": {
     "title": "Sentinel-1 GRD Zarr Product Exploration",
     "description": "Explore how to open, inspect the metadata and visualise Sentinel-1 GRD Zarr format",
-    "tags": ["xarray", "land", "sentinel-1"],
+    "tags": [
+      "land",
+      "sentinel-1",
+      "xarray"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -314,7 +463,11 @@
   "Sentinel-1/Sentinel-1_L2_OCN_Zarr_product_exploration": {
     "title": "Sentinel-1 L2 OCN Zarr Product Exploration",
     "description": "Explore how to open, visualise and use Sentinel-1 OCN products in EOPF Zarr format",
-    "tags": ["marine", "xarray", "sentinel-1"],
+    "tags": [
+      "marine",
+      "sentinel-1",
+      "xarray"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -322,7 +475,11 @@
   "Sentinel-1/Sentinel-1_Soil_moisture": {
     "title": "Sentinel 1 Surface Soil Moisture (SSM)",
     "description": "Learn how to compute surface soil moisture from Sentinel-1 data",
-    "tags": ["xarray", "land", "sentinel-1"],
+    "tags": [
+      "land",
+      "sentinel-1",
+      "xarray"
+    ],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -330,7 +487,11 @@
   "Sentinel-1/Sentinel-1_L1_SLC_Zarr_product_exploration": {
     "title": "Sentinel-1 SLC Zarr Product Exploration",
     "description": "Explore how to open, inspect the metadata and process Sentinel-1 Single Look Complex (SLC) Zarr format",
-    "tags": ["xarray", "land", "sentinel-1"],
+    "tags": [
+      "land",
+      "sentinel-1",
+      "xarray"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -338,7 +499,10 @@
   "Sentinel-1/GDAL_Sentinel-1_SLC_Burst_Selection": {
     "title": "Sentinel-1 SLC Burst Selection with EOPFZARR GDAL Driver",
     "description": "Directly access individual bursts from Sentinel-1 SLC products using the BURST open option",
-    "tags": ["gdal", "sentinel-1"],
+    "tags": [
+      "sentinel-1",
+      "gdal"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -346,7 +510,11 @@
   "Sentinel-1/radar_vegetation_index": {
     "title": "Radar Vegetation Index",
     "description": "Monitor vegetation crop growth using Sentinel-1 GRD data",
-    "tags": ["xarray", "land", "sentinel-1"],
+    "tags": [
+      "land",
+      "sentinel-1",
+      "xarray"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -354,7 +522,11 @@
   "xcube_eopf_plugin/introduction": {
     "title": "Introduction to the xcube EOPF Data Store",
     "description": "Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.",
-    "tags": ["sentinel-2", "xcube", "land"],
+    "tags": [
+      "land",
+      "sentinel-2",
+      "xcube"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xcube_eopf_plugin"
@@ -362,7 +534,11 @@
   "xcube_eopf_plugin/sentinel_3": {
     "title": "Building Sentinel-3 Data Cubes with xcube EOPF Data Store",
     "description": "Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.",
-    "tags": ["sentinel-3", "xcube", "land"],
+    "tags": [
+      "land",
+      "sentinel-3",
+      "xcube"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xcube_eopf_plugin"
@@ -370,7 +546,11 @@
   "xcube_eopf_plugin/sentinel_2": {
     "title": "Building Sentinel-2 Data Cubes with xcube EOPF Data Store",
     "description": "Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.",
-    "tags": ["sentinel-2", "xcube", "land"],
+    "tags": [
+      "land",
+      "sentinel-2",
+      "xcube"
+    ],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xcube_eopf_plugin"

--- a/notebooks/.gallery-metadata.json
+++ b/notebooks/.gallery-metadata.json
@@ -2,11 +2,7 @@
   "STAC/Data_Access_Tutorial": {
     "title": "Accessing Zarr Data",
     "description": "Explore how to access Data in Zarr format.",
-    "tags": [
-      "sentinel-2",
-      "xarray",
-      "land"
-    ],
+    "tags": ["sentinel-2", "xarray", "land"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "STAC"
@@ -14,11 +10,7 @@
   "STAC/STAC_EOPF_ZARR_SENTINEL": {
     "title": "STAC-Based Exploration and Visualization of Sentinel-2 and Sentinel-1 Data",
     "description": "Learn how to access Sentinel-2 and Sentinel-1 images via the EOPF STAC Catalog using pystac-client",
-    "tags": [
-      "stac",
-      "land",
-      "sentinel-1"
-    ],
+    "tags": ["stac", "land", "sentinel-1"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "STAC"
@@ -26,11 +18,7 @@
   "xarray_eopf_plugin/introduction": {
     "title": "Intoduction to the xarray EOPF backend",
     "description": "Access and explore analysis-ready and native EOPF Zarr data using xarray",
-    "tags": [
-      "sentinel-2",
-      "xarray-eopf",
-      "land"
-    ],
+    "tags": ["sentinel-2", "xarray-eopf", "land"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -38,11 +26,7 @@
   "xarray_eopf_plugin/sentinel_2_analysis": {
     "title": "xarray EOPF backend - Sentinel-2 Analysis Mode",
     "description": "Learn how to access Sentinel-2 products in analysis mode",
-    "tags": [
-      "sentinel-2",
-      "xarray-eopf",
-      "land"
-    ],
+    "tags": ["sentinel-2", "xarray-eopf", "land"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -50,11 +34,7 @@
   "xarray_eopf_plugin/sentinel_2_native": {
     "title": "xarray EOPF backend - Sentinel-2 Native mode",
     "description": "Learn how to access Sentinel-2 products in native mode",
-    "tags": [
-      "sentinel-2",
-      "xarray-eopf",
-      "land"
-    ],
+    "tags": ["sentinel-2", "xarray-eopf", "land"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -62,11 +42,7 @@
   "xarray_eopf_plugin/sentinel_3_native": {
     "title": "xarray EOPF backend - Sentinel-3 Native Mode",
     "description": "Learn how to access Sentinel-3 products in native mode",
-    "tags": [
-      "sentinel-3",
-      "xarray-eopf",
-      "land"
-    ],
+    "tags": ["sentinel-3", "xarray-eopf", "land"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -74,11 +50,7 @@
   "xarray_eopf_plugin/sentinel_1_native": {
     "title": "xarray EOPF backend - Sentinel-1 Native Mode",
     "description": "Learn how to access Sentinel-1 products in native mode",
-    "tags": [
-      "xarray-eopf",
-      "land",
-      "sentinel-1"
-    ],
+    "tags": ["xarray-eopf", "land", "sentinel-1"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -86,11 +58,7 @@
   "xarray_eopf_plugin/sentinel_3_analysis": {
     "title": "xarray EOPF backend - Sentinel-3 Analysis Mode",
     "description": "Learn how to access Sentinel-3 products in analysis mode",
-    "tags": [
-      "sentinel-3",
-      "xarray-eopf",
-      "land"
-    ],
+    "tags": ["sentinel-3", "xarray-eopf", "land"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xarray_eopf_plugin"
@@ -98,11 +66,7 @@
   "performance/sentinel_performance_zarr_safe_xcube": {
     "title": "EOPF zarr Performance Comparison - xcube",
     "description": "Compare the performance of the Sentinel EOPF zarr format to the SAFE format using the xcube readers.",
-    "tags": [
-      "sentinel-2",
-      "xcube",
-      "performance"
-    ],
+    "tags": ["sentinel-2", "xcube", "performance"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "performance"
@@ -110,10 +74,7 @@
   "performance/sentinel_performance_zarr_safe_direct": {
     "title": "EOPF zarr Performance Comparison - direct read",
     "description": "Compare the performance of the Sentinel EOPF zarr format to the SAFE format reading the files directly.",
-    "tags": [
-      "sentinel-2",
-      "performance"
-    ],
+    "tags": ["sentinel-2", "performance"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "performance"
@@ -121,12 +82,7 @@
   "Sentinel-2/eopf_openeo_stac_remote": {
     "title": "EOPF Zarr Data Access with openEO and STAC",
     "description": "Learn how to use the EOPF Zarr data through STAC and openEO",
-    "tags": [
-      "openeo",
-      "stac",
-      "land",
-      "sentinel-2"
-    ],
+    "tags": ["openeo", "stac", "land", "sentinel-2"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -134,10 +90,7 @@
   "Sentinel-2/Sentinel-2_L1C_data_access": {
     "title": "Sentinel-2 L1C Data Access",
     "description": "Demonstrate how to access Sentinel-2 L1C data in EOPF Zarr format",
-    "tags": [
-      "sentinel-2",
-      "basic"
-    ],
+    "tags": ["sentinel-2", "basic"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -145,11 +98,7 @@
   "Sentinel-2/Random_Forest_Land_Cover": {
     "title": "Random Forest Based Land-Cover Mapping with Sentinel-2",
     "description": "Demonstrate how to perform a basic land cover mapping using random forest and the Sentinel-2 data in EOPF Zarr format",
-    "tags": [
-      "sentinel-2",
-      "xcube",
-      "land"
-    ],
+    "tags": ["sentinel-2", "xcube", "land"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -157,11 +106,7 @@
   "Sentinel-2/sentinel-2_crop_type_classification_rule-based": {
     "title": "Sentinel-2 Crop-Type Classification",
     "description": "",
-    "tags": [
-      "sentinel-2",
-      "xarray",
-      "land"
-    ],
+    "tags": ["sentinel-2", "xarray", "land"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -169,11 +114,7 @@
   "Sentinel-2/NDVI_based_landslide_mapping": {
     "title": "NDVI-based approach to study Landslide areas",
     "description": "Streamlining Cloud-Based Processing with EOPF and Xarray",
-    "tags": [
-      "security",
-      "sentinel-2",
-      "xarray"
-    ],
+    "tags": ["security", "sentinel-2", "xarray"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -181,11 +122,7 @@
   "Sentinel-2/deforestation_monitoring_zarr": {
     "title": "Deforestation Monitoring using Sentinel 2 and xarray",
     "description": "Streamlining Cloud-Based Processing with EOPF and Xarray",
-    "tags": [
-      "security",
-      "sentinel-2",
-      "xarray"
-    ],
+    "tags": ["security", "sentinel-2", "xarray"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -193,11 +130,7 @@
   "Sentinel-2/parcel_delineation_sentinel": {
     "title": "Parcel delineation using Sentinel-2",
     "description": "Delineating agricultural parcels based on a neural network, using Sentinel-2 input data",
-    "tags": [
-      "sentinel-2",
-      "xarray",
-      "land"
-    ],
+    "tags": ["sentinel-2", "xarray", "land"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -205,12 +138,7 @@
   "Sentinel-2/eopf_openeo_stac": {
     "title": "EOPF Zarr Data Access with openEO and STAC",
     "description": "Learn how to use the EOPF Zarr data through STAC and openEO",
-    "tags": [
-      "openeo",
-      "stac",
-      "land",
-      "sentinel-2"
-    ],
+    "tags": ["openeo", "stac", "land", "sentinel-2"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -218,11 +146,7 @@
   "Sentinel-2/GDAL_explore_Zarr": {
     "title": "Explore EOPF Zarr Sentinel-2 files using GDAL",
     "description": "Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format",
-    "tags": [
-      "sentinel-2",
-      "land",
-      "gdal"
-    ],
+    "tags": ["sentinel-2", "land", "gdal"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -230,11 +154,7 @@
   "Sentinel-2/Sentinel-2_wildfire_mapping": {
     "title": "Wildfire Burn Severity Assessment Using Sentinel-2 L2A Data and dNBR",
     "description": "A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Ger\u00eas wildfire event (Portugal, July 2025).",
-    "tags": [
-      "climate-change",
-      "sentinel-2",
-      "stac"
-    ],
+    "tags": ["climate-change", "sentinel-2", "stac"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -242,11 +162,7 @@
   "Sentinel-2/oil_spill_index": {
     "title": "OSI - Oil Spill Index",
     "description": "Learn how to use the Oil Spill Index (OSI) to detect oil spills using Sentine-2 data.",
-    "tags": [
-      "sentinel 2",
-      "marine",
-      "stac"
-    ],
+    "tags": ["sentinel 2", "marine", "stac"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -254,11 +170,7 @@
   "Sentinel-2/Sentinel-2_NDSI_Snow_Mapping": {
     "title": "NDSI based snow mapping with Sentinel-2",
     "description": "Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format",
-    "tags": [
-      "climate-change",
-      "sentinel-2",
-      "xcube"
-    ],
+    "tags": ["climate-change", "sentinel-2", "xcube"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -266,11 +178,7 @@
   "Sentinel-2/oceanographic_wave_spectral_analysis": {
     "title": "Transforming workflow for oceanography study using Sentinel\u20112 data, from SAFE to Zarr",
     "description": "Computing wave spectra with 2D FFT & coherence in the EOPF framework",
-    "tags": [
-      "marine",
-      "xarray",
-      "sentinel-2"
-    ],
+    "tags": ["marine", "xarray", "sentinel-2"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -278,11 +186,7 @@
   "Sentinel-2/Potato_Field_Crop_Type": {
     "title": "NDVI Time-Series Analysis of Potato Fields",
     "description": "A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.",
-    "tags": [
-      "sentinel-2",
-      "xarray",
-      "land"
-    ],
+    "tags": ["sentinel-2", "xarray", "land"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -290,11 +194,7 @@
   "Sentinel-2/SAFE_Zarr_Metadata_Comparison_S2_L2A": {
     "title": "Zarr vs SAFE Metadata",
     "description": "Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)",
-    "tags": [
-      "sentinel-2",
-      "land",
-      "gdal"
-    ],
+    "tags": ["sentinel-2", "land", "gdal"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -302,11 +202,7 @@
   "Sentinel-2/water_level_timeseries": {
     "title": "Surface Water Level Monitoring with Sentinel-2",
     "description": "Timeseries of water covered area at Santa Giustina lake, Italy",
-    "tags": [
-      "climate-change",
-      "sentinel-2",
-      "xarray"
-    ],
+    "tags": ["climate-change", "sentinel-2", "xarray"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -314,10 +210,7 @@
   "Sentinel-2/Sentinel-2_L2A_data_access": {
     "title": "Sentinel-2 L2A Data Access",
     "description": "Demonstrate how to access Sentinel-2 L2A data in EOPF Zarr format",
-    "tags": [
-      "sentinel-2",
-      "basic"
-    ],
+    "tags": ["sentinel-2", "basic"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -325,11 +218,7 @@
   "Sentinel-2/Sentinel-2_snow_cover_fraction": {
     "title": "Analysing snow cover in the Alps using Sentinel-2",
     "description": "Learn how to use the EOPF Zarr data to analyse snow cover dynamics in the Alps with Sentinel-2 imagery.",
-    "tags": [
-      "sentinel-2",
-      "stac",
-      "land"
-    ],
+    "tags": ["sentinel-2", "stac", "land"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -337,11 +226,7 @@
   "Sentinel-2/Sentinel-2_L1C_MSI_Zarr_product_exploration": {
     "title": "Sentinel-2 L1C MSI Zarr Product Exploration",
     "description": "Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format",
-    "tags": [
-      "sentinel-2",
-      "xarray",
-      "land"
-    ],
+    "tags": ["sentinel-2", "xarray", "land"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-2"
@@ -349,10 +234,7 @@
   "Sentinel-3/Sentinel-3_OLCI_L2_LFR_data_access": {
     "title": "Sentinel-3 OLCI L2 LFR Data Access",
     "description": "Demonstrate how to access Sentinel-3 OLCI L2 LFR data in EOPF Zarr format",
-    "tags": [
-      "sentinel-3",
-      "basic"
-    ],
+    "tags": ["sentinel-3", "basic"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -360,11 +242,7 @@
   "Sentinel-3/GDAL_Sentinel-3-OLCI-Level-1-EFR": {
     "title": "Open Sentinel-3-OLCI-Level-1-EFR Data with GDAL and eopfzarr",
     "description": "",
-    "tags": [
-      "climate-change",
-      "sentinel-3",
-      "gdal"
-    ],
+    "tags": ["climate-change", "sentinel-3", "gdal"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -372,10 +250,7 @@
   "Sentinel-3/Sentinel-3_SLSTR_L2_LST_data_access": {
     "title": "Sentinel-3 SLSTR L2 LST Data Access",
     "description": "Demonstrate how to access Sentinel-3 SLSTR L2 LST data in EOPF Zarr format",
-    "tags": [
-      "sentinel-3",
-      "basic"
-    ],
+    "tags": ["sentinel-3", "basic"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -383,11 +258,7 @@
   "Sentinel-3/Sentinel-3_Heatwave_Mapping": {
     "title": "Heatwave in Netherlands",
     "description": "Learn how to read, process and use Sentinel-3 Land Surface Temperature",
-    "tags": [
-      "climate-change",
-      "sentinel-3",
-      "xarray"
-    ],
+    "tags": ["climate-change", "sentinel-3", "xarray"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -395,11 +266,7 @@
   "Sentinel-3/GDAL_Sentinel-3_Multi-Product-Demo": {
     "title": "Sentinel-3 Multi-Product Demo with GDAL",
     "description": "Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver",
-    "tags": [
-      "climate-change",
-      "sentinel-3",
-      "gdal"
-    ],
+    "tags": ["climate-change", "sentinel-3", "gdal"],
     "thumbnail": "../static/ESA_EOPF_logo_2025_COLOR_ESA_blue_reduced.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -407,11 +274,7 @@
   "Sentinel-3/Regridding_Sentinel_3_SLSTR_LST": {
     "title": "Regridding Sentinel-3 SLSTR Data",
     "description": "Learn how to regridding Sentinel-3 SLSTR data",
-    "tags": [
-      "climate-change",
-      "sentinel-3",
-      "xarray"
-    ],
+    "tags": ["climate-change", "sentinel-3", "xarray"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -419,10 +282,7 @@
   "Sentinel-3/Sentinel-3_OLCI_L1_EFR_data_access": {
     "title": "Sentinel-3 OLCI L1 EFR Data Access",
     "description": "Demonstrate how to access Sentinel-3 OLCI L1 EFR data in EOPF Zarr format",
-    "tags": [
-      "sentinel-3",
-      "basic"
-    ],
+    "tags": ["sentinel-3", "basic"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-3"
@@ -430,9 +290,7 @@
   "Dask/Dask_Intro": {
     "title": "Dask Intro",
     "description": "Explore how to connect to the dask gateway, spin up and scale a cluster and submit a simple workload.",
-    "tags": [
-      "dask"
-    ],
+    "tags": ["dask"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Dask"
@@ -440,10 +298,7 @@
   "Sentinel-1/GDAL_Sentinel-1_GCP_Geolocation": {
     "title": "Sentinel-1 GRD Geolocation with EOPFZARR Driver",
     "description": "Ground Control Point (GCP) based geolocation for Sentinel-1 GRD products using the EOPFZARR GDAL driver",
-    "tags": [
-      "gdal",
-      "sentinel-1"
-    ],
+    "tags": ["gdal", "sentinel-1"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -451,11 +306,7 @@
   "Sentinel-1/Sentinel-1_L1_GRD_Zarr_product_exploration": {
     "title": "Sentinel-1 GRD Zarr Product Exploration",
     "description": "Explore how to open, inspect the metadata and visualise Sentinel-1 GRD Zarr format",
-    "tags": [
-      "xarray",
-      "land",
-      "sentinel-1"
-    ],
+    "tags": ["xarray", "land", "sentinel-1"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -463,11 +314,7 @@
   "Sentinel-1/Sentinel-1_L2_OCN_Zarr_product_exploration": {
     "title": "Sentinel-1 L2 OCN Zarr Product Exploration",
     "description": "Explore how to open, visualise and use Sentinel-1 OCN products in EOPF Zarr format",
-    "tags": [
-      "marine",
-      "xarray",
-      "sentinel-1"
-    ],
+    "tags": ["marine", "xarray", "sentinel-1"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -475,11 +322,7 @@
   "Sentinel-1/Sentinel-1_Soil_moisture": {
     "title": "Sentinel 1 Surface Soil Moisture (SSM)",
     "description": "Learn how to compute surface soil moisture from Sentinel-1 data",
-    "tags": [
-      "xarray",
-      "land",
-      "sentinel-1"
-    ],
+    "tags": ["xarray", "land", "sentinel-1"],
     "thumbnail": "https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -487,11 +330,7 @@
   "Sentinel-1/Sentinel-1_L1_SLC_Zarr_product_exploration": {
     "title": "Sentinel-1 SLC Zarr Product Exploration",
     "description": "Explore how to open, inspect the metadata and process Sentinel-1 Single Look Complex (SLC) Zarr format",
-    "tags": [
-      "xarray",
-      "land",
-      "sentinel-1"
-    ],
+    "tags": ["xarray", "land", "sentinel-1"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -499,10 +338,7 @@
   "Sentinel-1/GDAL_Sentinel-1_SLC_Burst_Selection": {
     "title": "Sentinel-1 SLC Burst Selection with EOPFZARR GDAL Driver",
     "description": "Directly access individual bursts from Sentinel-1 SLC products using the BURST open option",
-    "tags": [
-      "gdal",
-      "sentinel-1"
-    ],
+    "tags": ["gdal", "sentinel-1"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -510,11 +346,7 @@
   "Sentinel-1/radar_vegetation_index": {
     "title": "Radar Vegetation Index",
     "description": "Monitor vegetation crop growth using Sentinel-1 GRD data",
-    "tags": [
-      "xarray",
-      "land",
-      "sentinel-1"
-    ],
+    "tags": ["xarray", "land", "sentinel-1"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "Sentinel-1"
@@ -522,11 +354,7 @@
   "xcube_eopf_plugin/introduction": {
     "title": "Introduction to the xcube EOPF Data Store",
     "description": "Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.",
-    "tags": [
-      "sentinel-2",
-      "xcube",
-      "land"
-    ],
+    "tags": ["sentinel-2", "xcube", "land"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xcube_eopf_plugin"
@@ -534,11 +362,7 @@
   "xcube_eopf_plugin/sentinel_3": {
     "title": "Building Sentinel-3 Data Cubes with xcube EOPF Data Store",
     "description": "Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.",
-    "tags": [
-      "sentinel-3",
-      "xcube",
-      "land"
-    ],
+    "tags": ["sentinel-3", "xcube", "land"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xcube_eopf_plugin"
@@ -546,11 +370,7 @@
   "xcube_eopf_plugin/sentinel_2": {
     "title": "Building Sentinel-2 Data Cubes with xcube EOPF Data Store",
     "description": "Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.",
-    "tags": [
-      "sentinel-2",
-      "xcube",
-      "land"
-    ],
+    "tags": ["sentinel-2", "xcube", "land"],
     "thumbnail": "../static/EOPF-on-bright-baseline.png",
     "has_explicit_tags": true,
     "folder": "xcube_eopf_plugin"

--- a/notebooks/gallery-sentinel.md
+++ b/notebooks/gallery-sentinel.md
@@ -13,28 +13,28 @@ Notebooks showcasing Sentinel mission data processing and analysis
 ## Sentinel-1
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Radar Vegetation Index</strong><br>
-    Monitor vegetation crop growth using Sentinel-1 GRD data
+    Monitor vegetation crop growth using Sentinel-1 GRD data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-1/radar_vegetation_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel 1 Surface Soil Moisture (SSM)</strong><br>
-    Learn how to compute surface soil moisture from Sentinel-1 data
+    Learn how to compute surface soil moisture from Sentinel-1 data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_Soil_moisture" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -45,35 +45,35 @@ Notebooks showcasing Sentinel mission data processing and analysis
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-1 GRD Geolocation with EOPFZARR Driver</strong><br>
-    Ground Control Point (GCP) based geolocation for Sentinel-1 GRD products using the EOPFZARR GDAL driver
+    Ground Control Point (GCP) based geolocation for Sentinel-1 GRD products using the EOPFZARR GDAL driver<br>
     <div style="margin: 6px 0;">
       <span class="tag">sentinel-1</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-1/GDAL_Sentinel-1_GCP_Geolocation" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-1 GRD Zarr Product Exploration</strong><br>
-    Explore how to open, inspect the metadata and visualise Sentinel-1 GRD Zarr format
+    Explore how to open, inspect the metadata and visualise Sentinel-1 GRD Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L1_GRD_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="marine sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-1 L2 OCN Zarr Product Exploration</strong><br>
-    Explore how to open, visualise and use Sentinel-1 OCN products in EOPF Zarr format
+    Explore how to open, visualise and use Sentinel-1 OCN products in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">marine</span>
+      <span class="tag">marine</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L2_OCN_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -84,48 +84,48 @@ Notebooks showcasing Sentinel mission data processing and analysis
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-1 SLC Burst Selection with EOPFZARR GDAL Driver</strong><br>
-    Directly access individual bursts from Sentinel-1 SLC products using the BURST open option
+    Directly access individual bursts from Sentinel-1 SLC products using the BURST open option<br>
     <div style="margin: 6px 0;">
       <span class="tag">sentinel-1</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-1/GDAL_Sentinel-1_SLC_Burst_Selection" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-1 SLC Zarr Product Exploration</strong><br>
-    Explore how to open, inspect the metadata and process Sentinel-1 Single Look Complex (SLC) Zarr format
+    Explore how to open, inspect the metadata and process Sentinel-1 Single Look Complex (SLC) Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L1_SLC_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 stac land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land stac sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>STAC-Based Exploration and Visualization of Sentinel-2 and Sentinel-1 Data</strong><br>
-    Learn how to access Sentinel-2 and Sentinel-1 images via the EOPF STAC Catalog using pystac-client
+    Learn how to access Sentinel-2 and Sentinel-1 images via the EOPF STAC Catalog using pystac-client<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">stac</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">stac</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/STAC/STAC_EOPF_ZARR_SENTINEL" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 land xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>xarray EOPF backend - Sentinel-1 Native Mode</strong><br>
-    Learn how to access Sentinel-1 products in native mode
+    Learn how to access Sentinel-1 products in native mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">land</span><span class="tag">xarray-eopf</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_1_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -135,41 +135,41 @@ Notebooks showcasing Sentinel mission data processing and analysis
 ## Sentinel-2
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Accessing Zarr Data</strong><br>
-    Explore how to access Data in Zarr format.
+    Explore how to access Data in Zarr format.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/STAC/Data_Access_Tutorial" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="stac land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land stac sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Analysing snow cover in the Alps using Sentinel-2</strong><br>
-    Learn how to use the EOPF Zarr data to analyse snow cover dynamics in the Alps with Sentinel-2 imagery.
+    Learn how to use the EOPF Zarr data to analyse snow cover dynamics in the Alps with Sentinel-2 imagery.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">stac</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">stac</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_snow_cover_fraction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Building Sentinel-2 Data Cubes with xcube EOPF Data Store</strong><br>
-    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.
+    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/sentinel_2" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -180,74 +180,74 @@ Notebooks showcasing Sentinel mission data processing and analysis
   </div>
   <div style="flex: 1;">
     <strong>Deforestation Monitoring using Sentinel 2 and xarray</strong><br>
-    Streamlining Cloud-Based Processing with EOPF and Xarray
+    Streamlining Cloud-Based Processing with EOPF and Xarray<br>
     <div style="margin: 6px 0;">
       <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/deforestation_monitoring_zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land stac openeo sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land openeo stac sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
-    Learn how to use the EOPF Zarr data through STAC and openEO
+    Learn how to use the EOPF Zarr data through STAC and openEO<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">stac</span><span class="tag">openeo</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">openeo</span><span class="tag">stac</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/eopf_openeo_stac_remote" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land stac openeo sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land openeo stac sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
-    Learn how to use the EOPF Zarr data through STAC and openEO
+    Learn how to use the EOPF Zarr data through STAC and openEO<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">stac</span><span class="tag">openeo</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">openeo</span><span class="tag">stac</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/eopf_openeo_stac" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="performance sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-2 performance" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>EOPF zarr Performance Comparison - direct read</strong><br>
-    Compare the performance of the Sentinel EOPF zarr format to the SAFE format reading the files directly.
+    Compare the performance of the Sentinel EOPF zarr format to the SAFE format reading the files directly.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">performance</span><span class="tag">sentinel-2</span>
+      <span class="tag">sentinel-2</span><span class="tag">performance</span>
     </div>
     <a href="/notebooks/performance/sentinel_performance_zarr_safe_direct" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="performance xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-2 performance xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>EOPF zarr Performance Comparison - xcube</strong><br>
-    Compare the performance of the Sentinel EOPF zarr format to the SAFE format using the xcube readers.
+    Compare the performance of the Sentinel EOPF zarr format to the SAFE format using the xcube readers.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">performance</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
+      <span class="tag">sentinel-2</span><span class="tag">performance</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/performance/sentinel_performance_zarr_safe_xcube" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="gdal land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land gdal sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Explore EOPF Zarr Sentinel-2 files using GDAL</strong><br>
-    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
+    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">gdal</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">gdal</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/GDAL_explore_Zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -258,48 +258,48 @@ Notebooks showcasing Sentinel mission data processing and analysis
   </div>
   <div style="flex: 1;">
     <strong>Intoduction to the xarray EOPF backend</strong><br>
-    Access and explore analysis-ready and native EOPF Zarr data using xarray
+    Access and explore analysis-ready and native EOPF Zarr data using xarray<br>
     <div style="margin: 6px 0;">
       <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Introduction to the xcube EOPF Data Store</strong><br>
-    Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.
+    Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change sentinel-2 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>NDSI based snow mapping with Sentinel-2</strong><br>
-    Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format
+    Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
+      <span class="tag">climate-change</span><span class="tag">sentinel-2</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_NDSI_Snow_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>NDVI Time-Series Analysis of Potato Fields</strong><br>
-    A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.
+    A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Potato_Field_Crop_Type" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -310,48 +310,47 @@ Notebooks showcasing Sentinel mission data processing and analysis
   </div>
   <div style="flex: 1;">
     <strong>NDVI-based approach to study Landslide areas</strong><br>
-    Streamlining Cloud-Based Processing with EOPF and Xarray
+    Streamlining Cloud-Based Processing with EOPF and Xarray<br>
     <div style="margin: 6px 0;">
       <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/NDVI_based_landslide_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Parcel delineation using Sentinel-2</strong><br>
-    Delineating agricultural parcels based on a neural network, using Sentinel-2 input data
+    Delineating agricultural parcels based on a neural network, using Sentinel-2 input data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/parcel_delineation_sentinel" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Random Forest Based Land-Cover Mapping with Sentinel-2</strong><br>
-    Demonstrate how to perform a basic land cover mapping using random forest and the Sentinel-2 data in EOPF Zarr format
+    Demonstrate how to perform a basic land cover mapping using random forest and the Sentinel-2 data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/Sentinel-2/Random_Forest_Land_Cover" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-2 Crop-Type Classification</strong><br>
-    
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/sentinel-2_crop_type_classification_rule-based" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -362,22 +361,22 @@ Notebooks showcasing Sentinel mission data processing and analysis
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-2 L1C Data Access</strong><br>
-    Demonstrate how to access Sentinel-2 L1C data in EOPF Zarr format
+    Demonstrate how to access Sentinel-2 L1C data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
       <span class="tag">basic</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-2 L1C MSI Zarr Product Exploration</strong><br>
-    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
+    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_MSI_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -388,48 +387,48 @@ Notebooks showcasing Sentinel mission data processing and analysis
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-2 L2A Data Access</strong><br>
-    Demonstrate how to access Sentinel-2 L2A data in EOPF Zarr format
+    Demonstrate how to access Sentinel-2 L2A data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
       <span class="tag">basic</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_L2A_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray climate-change sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Surface Water Level Monitoring with Sentinel-2</strong><br>
-    Timeseries of water covered area at Santa Giustina lake, Italy
+    Timeseries of water covered area at Santa Giustina lake, Italy<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">climate-change</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/water_level_timeseries" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray marine sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="marine xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Transforming workflow for oceanography study using Sentinel‑2 data, from SAFE to Zarr</strong><br>
-    Computing wave spectra with 2D FFT & coherence in the EOPF framework
+    Computing wave spectra with 2D FFT & coherence in the EOPF framework<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">marine</span><span class="tag">sentinel-2</span>
+      <span class="tag">marine</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/oceanographic_wave_spectral_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change stac sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="stac climate-change sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Wildfire Burn Severity Assessment Using Sentinel-2 L2A Data and dNBR</strong><br>
-    A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Gerês wildfire event (Portugal, July 2025).
+    A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Gerês wildfire event (Portugal, July 2025).<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">stac</span><span class="tag">sentinel-2</span>
+      <span class="tag">stac</span><span class="tag">climate-change</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_wildfire_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -440,7 +439,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
   </div>
   <div style="flex: 1;">
     <strong>xarray EOPF backend - Sentinel-2 Analysis Mode</strong><br>
-    Learn how to access Sentinel-2 products in analysis mode
+    Learn how to access Sentinel-2 products in analysis mode<br>
     <div style="margin: 6px 0;">
       <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
@@ -453,22 +452,22 @@ Notebooks showcasing Sentinel mission data processing and analysis
   </div>
   <div style="flex: 1;">
     <strong>xarray EOPF backend - Sentinel-2 Native mode</strong><br>
-    Learn how to access Sentinel-2 products in native mode
+    Learn how to access Sentinel-2 products in native mode<br>
     <div style="margin: 6px 0;">
       <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_2_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="gdal land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land gdal sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Zarr vs SAFE Metadata</strong><br>
-    Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)
+    Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)<br>
     <div style="margin: 6px 0;">
-      <span class="tag">gdal</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">gdal</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/SAFE_Zarr_Metadata_Comparison_S2_L2A" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -478,134 +477,134 @@ Notebooks showcasing Sentinel mission data processing and analysis
 ## Sentinel-3
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="land xcube sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-3 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Building Sentinel-3 Data Cubes with xcube EOPF Data Store</strong><br>
-    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.
+    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-3</span>
+      <span class="tag">land</span><span class="tag">sentinel-3</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/sentinel_3" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change xarray sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Heatwave in Netherlands</strong><br>
-    Learn how to read, process and use Sentinel-3 Land Surface Temperature
+    Learn how to read, process and use Sentinel-3 Land Surface Temperature<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-3/Sentinel-3_Heatwave_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change gdal sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 climate-change gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Open Sentinel-3-OLCI-Level-1-EFR Data with GDAL and eopfzarr</strong><br>
-    
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">gdal</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3-OLCI-Level-1-EFR" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change xarray sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Regridding Sentinel-3 SLSTR Data</strong><br>
-    Learn how to regridding Sentinel-3 SLSTR data
+    Learn how to regridding Sentinel-3 SLSTR data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-3/Regridding_Sentinel_3_SLSTR_LST" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change gdal sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 climate-change gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/ESA_EOPF_logo_2025_COLOR_ESA_blue_reduced.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-3 Multi-Product Demo with GDAL</strong><br>
-    Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver
+    Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">gdal</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3_Multi-Product-Demo" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="basic sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 basic" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-3 OLCI L1 EFR Data Access</strong><br>
-    Demonstrate how to access Sentinel-3 OLCI L1 EFR data in EOPF Zarr format
+    Demonstrate how to access Sentinel-3 OLCI L1 EFR data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">basic</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">basic</span>
     </div>
     <a href="/notebooks/Sentinel-3/Sentinel-3_OLCI_L1_EFR_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="basic sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 basic" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-3 OLCI L2 LFR Data Access</strong><br>
-    Demonstrate how to access Sentinel-3 OLCI L2 LFR data in EOPF Zarr format
+    Demonstrate how to access Sentinel-3 OLCI L2 LFR data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">basic</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">basic</span>
     </div>
     <a href="/notebooks/Sentinel-3/Sentinel-3_OLCI_L2_LFR_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="basic sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 basic" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-3 SLSTR L2 LST Data Access</strong><br>
-    Demonstrate how to access Sentinel-3 SLSTR L2 LST data in EOPF Zarr format
+    Demonstrate how to access Sentinel-3 SLSTR L2 LST data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">basic</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">basic</span>
     </div>
     <a href="/notebooks/Sentinel-3/Sentinel-3_SLSTR_L2_LST_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-3 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>xarray EOPF backend - Sentinel-3 Analysis Mode</strong><br>
-    Learn how to access Sentinel-3 products in analysis mode
+    Learn how to access Sentinel-3 products in analysis mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span>
+      <span class="tag">land</span><span class="tag">sentinel-3</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_3_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-3 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>xarray EOPF backend - Sentinel-3 Native Mode</strong><br>
-    Learn how to access Sentinel-3 products in native mode
+    Learn how to access Sentinel-3 products in native mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span>
+      <span class="tag">land</span><span class="tag">sentinel-3</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_3_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
 </div>
+

--- a/notebooks/gallery-sentinel.md
+++ b/notebooks/gallery-sentinel.md
@@ -12,21 +12,601 @@ Notebooks showcasing Sentinel mission data processing and analysis
 
 ## Sentinel-1
 
-```{gallery-grid}
-:category: sentinel-1
-:columns: 1 1 2 3
-```
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Radar Vegetation Index</strong><br>
+    Monitor vegetation crop growth using Sentinel-1 GRD data
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/radar_vegetation_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel 1 Surface Soil Moisture (SSM)</strong><br>
+    Learn how to compute surface soil moisture from Sentinel-1 data
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/Sentinel-1_Soil_moisture" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="gdal sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-1 GRD Geolocation with EOPFZARR Driver</strong><br>
+    Ground Control Point (GCP) based geolocation for Sentinel-1 GRD products using the EOPFZARR GDAL driver
+    <div style="margin: 6px 0;">
+      <span class="tag">gdal</span><span class="tag">sentinel-1</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/GDAL_Sentinel-1_GCP_Geolocation" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-1 GRD Zarr Product Exploration</strong><br>
+    Explore how to open, inspect the metadata and visualise Sentinel-1 GRD Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/Sentinel-1_L1_GRD_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-1 L2 OCN Zarr Product Exploration</strong><br>
+    Explore how to open, visualise and use Sentinel-1 OCN products in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">marine</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/Sentinel-1_L2_OCN_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="gdal sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-1 SLC Burst Selection with EOPFZARR GDAL Driver</strong><br>
+    Directly access individual bursts from Sentinel-1 SLC products using the BURST open option
+    <div style="margin: 6px 0;">
+      <span class="tag">gdal</span><span class="tag">sentinel-1</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/GDAL_Sentinel-1_SLC_Burst_Selection" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-1 SLC Zarr Product Exploration</strong><br>
+    Explore how to open, inspect the metadata and process Sentinel-1 Single Look Complex (SLC) Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/Sentinel-1_L1_SLC_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>STAC-Based Exploration and Visualization of Sentinel-2 and Sentinel-1 Data</strong><br>
+    Learn how to access Sentinel-2 and Sentinel-1 images via the EOPF STAC Catalog using pystac-client
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">land</span><span class="tag">stac</span>
+    </div>
+    <a href="/notebooks/STAC/STAC_EOPF_ZARR_SENTINEL" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>xarray EOPF backend - Sentinel-1 Native Mode</strong><br>
+    Learn how to access Sentinel-1 products in native mode
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/sentinel_1_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+</div>
 
 ## Sentinel-2
 
-```{gallery-grid}
-:category: sentinel-2
-:columns: 1 1 2 3
-```
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Accessing Zarr Data</strong><br>
+    Explore how to access Data in Zarr format.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/STAC/Data_Access_Tutorial" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 stac land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Analysing snow cover in the Alps using Sentinel-2</strong><br>
+    Learn how to use the EOPF Zarr data to analyse snow cover dynamics in the Alps with Sentinel-2 imagery.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">stac</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Sentinel-2_snow_cover_fraction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Building Sentinel-2 Data Cubes with xcube EOPF Data Store</strong><br>
+    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xcube_eopf_plugin/sentinel_2" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Deforestation Monitoring using Sentinel 2 and xarray</strong><br>
+    Streamlining Cloud-Based Processing with EOPF and Xarray
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">security</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/deforestation_monitoring_zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 openeo land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
+    Learn how to use the EOPF Zarr data through STAC and openEO
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">openeo</span><span class="tag">land</span><span class="tag">stac</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/eopf_openeo_stac_remote" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 openeo land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
+    Learn how to use the EOPF Zarr data through STAC and openEO
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">openeo</span><span class="tag">land</span><span class="tag">stac</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/eopf_openeo_stac" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 performance" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>EOPF zarr Performance Comparison - direct read</strong><br>
+    Compare the performance of the Sentinel EOPF zarr format to the SAFE format reading the files directly.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">performance</span>
+    </div>
+    <a href="/notebooks/performance/sentinel_performance_zarr_safe_direct" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xcube performance" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>EOPF zarr Performance Comparison - xcube</strong><br>
+    Compare the performance of the Sentinel EOPF zarr format to the SAFE format using the xcube readers.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">performance</span>
+    </div>
+    <a href="/notebooks/performance/sentinel_performance_zarr_safe_xcube" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 land gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Explore EOPF Zarr Sentinel-2 files using GDAL</strong><br>
+    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">land</span><span class="tag">gdal</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/GDAL_explore_Zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Intoduction to the xarray EOPF backend</strong><br>
+    Access and explore analysis-ready and native EOPF Zarr data using xarray
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Introduction to the xcube EOPF Data Store</strong><br>
+    Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xcube_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 climate-change xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>NDSI based snow mapping with Sentinel-2</strong><br>
+    Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">xcube</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Sentinel-2_NDSI_Snow_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>NDVI Time-Series Analysis of Potato Fields</strong><br>
+    A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Potato_Field_Crop_Type" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>NDVI-based approach to study Landslide areas</strong><br>
+    Streamlining Cloud-Based Processing with EOPF and Xarray
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">security</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/NDVI_based_landslide_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Parcel delineation using Sentinel-2</strong><br>
+    Delineating agricultural parcels based on a neural network, using Sentinel-2 input data
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/parcel_delineation_sentinel" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Random Forest Based Land-Cover Mapping with Sentinel-2</strong><br>
+    Demonstrate how to perform a basic land cover mapping using random forest and the Sentinel-2 data in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Random_Forest_Land_Cover" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-2 Crop-Type Classification</strong><br>
+    
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/sentinel-2_crop_type_classification_rule-based" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="basic sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-2 L1C Data Access</strong><br>
+    Demonstrate how to access Sentinel-2 L1C data in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">basic</span><span class="tag">sentinel-2</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-2 L1C MSI Zarr Product Exploration</strong><br>
+    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_MSI_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="basic sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-2 L2A Data Access</strong><br>
+    Demonstrate how to access Sentinel-2 L2A data in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">basic</span><span class="tag">sentinel-2</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Sentinel-2_L2A_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Surface Water Level Monitoring with Sentinel-2</strong><br>
+    Timeseries of water covered area at Santa Giustina lake, Italy
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">xarray</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/water_level_timeseries" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Transforming workflow for oceanography study using Sentinel‑2 data, from SAFE to Zarr</strong><br>
+    Computing wave spectra with 2D FFT & coherence in the EOPF framework
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">marine</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/oceanographic_wave_spectral_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 climate-change stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Wildfire Burn Severity Assessment Using Sentinel-2 L2A Data and dNBR</strong><br>
+    A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Gerês wildfire event (Portugal, July 2025).
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">stac</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Sentinel-2_wildfire_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>xarray EOPF backend - Sentinel-2 Analysis Mode</strong><br>
+    Learn how to access Sentinel-2 products in analysis mode
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/sentinel_2_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>xarray EOPF backend - Sentinel-2 Native mode</strong><br>
+    Learn how to access Sentinel-2 products in native mode
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/sentinel_2_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 land gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Zarr vs SAFE Metadata</strong><br>
+    Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">land</span><span class="tag">gdal</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/SAFE_Zarr_Metadata_Comparison_S2_L2A" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+</div>
 
 ## Sentinel-3
 
-```{gallery-grid}
-:category: sentinel-3
-:columns: 1 1 2 3
-```
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div class="notebook-card" data-tags="xcube sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Building Sentinel-3 Data Cubes with xcube EOPF Data Store</strong><br>
+    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.
+    <div style="margin: 6px 0;">
+      <span class="tag">xcube</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xcube_eopf_plugin/sentinel_3" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="climate-change sentinel-3 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Heatwave in Netherlands</strong><br>
+    Learn how to read, process and use Sentinel-3 Land Surface Temperature
+    <div style="margin: 6px 0;">
+      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">xarray</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/Sentinel-3_Heatwave_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="gdal climate-change sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Open Sentinel-3-OLCI-Level-1-EFR Data with GDAL and eopfzarr</strong><br>
+    
+    <div style="margin: 6px 0;">
+      <span class="tag">gdal</span><span class="tag">climate-change</span><span class="tag">sentinel-3</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3-OLCI-Level-1-EFR" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="climate-change sentinel-3 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Regridding Sentinel-3 SLSTR Data</strong><br>
+    Learn how to regridding Sentinel-3 SLSTR data
+    <div style="margin: 6px 0;">
+      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">xarray</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/Regridding_Sentinel_3_SLSTR_LST" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="gdal climate-change sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/ESA_EOPF_logo_2025_COLOR_ESA_blue_reduced.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-3 Multi-Product Demo with GDAL</strong><br>
+    Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver
+    <div style="margin: 6px 0;">
+      <span class="tag">gdal</span><span class="tag">climate-change</span><span class="tag">sentinel-3</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3_Multi-Product-Demo" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="basic sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-3 OLCI L1 EFR Data Access</strong><br>
+    Demonstrate how to access Sentinel-3 OLCI L1 EFR data in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">basic</span><span class="tag">sentinel-3</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/Sentinel-3_OLCI_L1_EFR_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="basic sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-3 OLCI L2 LFR Data Access</strong><br>
+    Demonstrate how to access Sentinel-3 OLCI L2 LFR data in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">basic</span><span class="tag">sentinel-3</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/Sentinel-3_OLCI_L2_LFR_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="basic sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-3 SLSTR L2 LST Data Access</strong><br>
+    Demonstrate how to access Sentinel-3 SLSTR L2 LST data in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">basic</span><span class="tag">sentinel-3</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/Sentinel-3_SLSTR_L2_LST_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="xarray-eopf sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>xarray EOPF backend - Sentinel-3 Analysis Mode</strong><br>
+    Learn how to access Sentinel-3 products in analysis mode
+    <div style="margin: 6px 0;">
+      <span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/sentinel_3_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="xarray-eopf sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>xarray EOPF backend - Sentinel-3 Native Mode</strong><br>
+    Learn how to access Sentinel-3 products in native mode
+    <div style="margin: 6px 0;">
+      <span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/sentinel_3_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+</div>
+

--- a/notebooks/gallery-sentinel.md
+++ b/notebooks/gallery-sentinel.md
@@ -12,8 +12,8 @@ Notebooks showcasing Sentinel mission data processing and analysis
 
 ## Sentinel-1
 
-<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px; margin-bottom: 40px;">
+<div class="notebook-card" data-tags="xarray land sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -21,12 +21,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Radar Vegetation Index</strong><br>
     Monitor vegetation crop growth using Sentinel-1 GRD data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/Sentinel-1/radar_vegetation_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -34,12 +34,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Sentinel 1 Surface Soil Moisture (SSM)</strong><br>
     Learn how to compute surface soil moisture from Sentinel-1 data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_Soil_moisture" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="gdal sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -47,12 +47,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Sentinel-1 GRD Geolocation with EOPFZARR Driver</strong><br>
     Ground Control Point (GCP) based geolocation for Sentinel-1 GRD products using the EOPFZARR GDAL driver<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">gdal</span>
+      <span class="tag">gdal</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/Sentinel-1/GDAL_Sentinel-1_GCP_Geolocation" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -60,12 +60,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Sentinel-1 GRD Zarr Product Exploration</strong><br>
     Explore how to open, inspect the metadata and visualise Sentinel-1 GRD Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L1_GRD_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="marine sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-1 marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -73,12 +73,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Sentinel-1 L2 OCN Zarr Product Exploration</strong><br>
     Explore how to open, visualise and use Sentinel-1 OCN products in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">marine</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-1</span><span class="tag">marine</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L2_OCN_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="gdal sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -86,12 +86,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Sentinel-1 SLC Burst Selection with EOPFZARR GDAL Driver</strong><br>
     Directly access individual bursts from Sentinel-1 SLC products using the BURST open option<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">gdal</span>
+      <span class="tag">gdal</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/Sentinel-1/GDAL_Sentinel-1_SLC_Burst_Selection" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -99,7 +99,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Sentinel-1 SLC Zarr Product Exploration</strong><br>
     Explore how to open, inspect the metadata and process Sentinel-1 Single Look Complex (SLC) Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L1_SLC_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -117,7 +117,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <a href="/notebooks/STAC/STAC_EOPF_ZARR_SENTINEL" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-1 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -125,7 +125,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>xarray EOPF backend - Sentinel-1 Native Mode</strong><br>
     Learn how to access Sentinel-1 products in native mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-1</span>
+      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_1_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -134,8 +134,8 @@ Notebooks showcasing Sentinel mission data processing and analysis
 
 ## Sentinel-2
 
-<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px; margin-bottom: 40px;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -143,7 +143,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Accessing Zarr Data</strong><br>
     Explore how to access Data in Zarr format.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/STAC/Data_Access_Tutorial" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -174,7 +174,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <a href="/notebooks/xcube_eopf_plugin/sentinel_2" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="security xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-2 security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -182,7 +182,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Deforestation Monitoring using Sentinel 2 and xarray</strong><br>
     Streamlining Cloud-Based Processing with EOPF and Xarray<br>
     <div style="margin: 6px 0;">
-      <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-2</span><span class="tag">security</span>
     </div>
     <a href="/notebooks/Sentinel-2/deforestation_monitoring_zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -239,7 +239,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <a href="/notebooks/performance/sentinel_performance_zarr_safe_xcube" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land gdal sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -247,12 +247,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Explore EOPF Zarr Sentinel-2 files using GDAL</strong><br>
     Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">gdal</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-2/GDAL_explore_Zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -260,7 +260,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Intoduction to the xarray EOPF backend</strong><br>
     Access and explore analysis-ready and native EOPF Zarr data using xarray<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -278,7 +278,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <a href="/notebooks/xcube_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change sentinel-2 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-2 climate-change xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -286,12 +286,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>NDSI based snow mapping with Sentinel-2</strong><br>
     Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">sentinel-2</span><span class="tag">xcube</span>
+      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_NDSI_Snow_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -299,12 +299,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>NDVI Time-Series Analysis of Potato Fields</strong><br>
     A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Potato_Field_Crop_Type" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="security xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-2 security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -312,12 +312,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>NDVI-based approach to study Landslide areas</strong><br>
     Streamlining Cloud-Based Processing with EOPF and Xarray<br>
     <div style="margin: 6px 0;">
-      <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-2</span><span class="tag">security</span>
     </div>
     <a href="/notebooks/Sentinel-2/NDVI_based_landslide_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -325,7 +325,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Parcel delineation using Sentinel-2</strong><br>
     Delineating agricultural parcels based on a neural network, using Sentinel-2 input data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/parcel_delineation_sentinel" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -343,19 +343,19 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <a href="/notebooks/Sentinel-2/Random_Forest_Land_Cover" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-2 Crop-Type Classification</strong><br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/sentinel-2_crop_type_classification_rule-based" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="basic sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-2 basic" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -363,12 +363,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Sentinel-2 L1C Data Access</strong><br>
     Demonstrate how to access Sentinel-2 L1C data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">basic</span><span class="tag">sentinel-2</span>
+      <span class="tag">sentinel-2</span><span class="tag">basic</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -376,12 +376,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Sentinel-2 L1C MSI Zarr Product Exploration</strong><br>
     Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_MSI_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="basic sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-2 basic" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -389,12 +389,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Sentinel-2 L2A Data Access</strong><br>
     Demonstrate how to access Sentinel-2 L2A data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">basic</span><span class="tag">sentinel-2</span>
+      <span class="tag">sentinel-2</span><span class="tag">basic</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_L2A_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray climate-change sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-2 climate-change" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -402,12 +402,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Surface Water Level Monitoring with Sentinel-2</strong><br>
     Timeseries of water covered area at Santa Giustina lake, Italy<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">climate-change</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-2</span><span class="tag">climate-change</span>
     </div>
     <a href="/notebooks/Sentinel-2/water_level_timeseries" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="marine xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-2 marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -415,12 +415,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Transforming workflow for oceanography study using Sentinel‑2 data, from SAFE to Zarr</strong><br>
     Computing wave spectra with 2D FFT & coherence in the EOPF framework<br>
     <div style="margin: 6px 0;">
-      <span class="tag">marine</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-2</span><span class="tag">marine</span>
     </div>
     <a href="/notebooks/Sentinel-2/oceanographic_wave_spectral_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="stac climate-change sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="stac sentinel-2 climate-change" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -428,12 +428,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Wildfire Burn Severity Assessment Using Sentinel-2 L2A Data and dNBR</strong><br>
     A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Gerês wildfire event (Portugal, July 2025).<br>
     <div style="margin: 6px 0;">
-      <span class="tag">stac</span><span class="tag">climate-change</span><span class="tag">sentinel-2</span>
+      <span class="tag">stac</span><span class="tag">sentinel-2</span><span class="tag">climate-change</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_wildfire_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -441,12 +441,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>xarray EOPF backend - Sentinel-2 Analysis Mode</strong><br>
     Learn how to access Sentinel-2 products in analysis mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_2_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -454,12 +454,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>xarray EOPF backend - Sentinel-2 Native mode</strong><br>
     Learn how to access Sentinel-2 products in native mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_2_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land gdal sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -467,7 +467,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Zarr vs SAFE Metadata</strong><br>
     Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">gdal</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-2/SAFE_Zarr_Metadata_Comparison_S2_L2A" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -476,7 +476,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
 
 ## Sentinel-3
 
-<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px; margin-bottom: 40px;">
 <div class="notebook-card" data-tags="land sentinel-3 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
@@ -490,7 +490,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <a href="/notebooks/xcube_eopf_plugin/sentinel_3" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-3 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-3 climate-change" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -498,24 +498,24 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Heatwave in Netherlands</strong><br>
     Learn how to read, process and use Sentinel-3 Land Surface Temperature<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-3</span><span class="tag">climate-change</span>
     </div>
     <a href="/notebooks/Sentinel-3/Sentinel-3_Heatwave_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-3 climate-change gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change sentinel-3 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Open Sentinel-3-OLCI-Level-1-EFR Data with GDAL and eopfzarr</strong><br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">gdal</span>
+      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3-OLCI-Level-1-EFR" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-3 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-3 climate-change" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -523,12 +523,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Regridding Sentinel-3 SLSTR Data</strong><br>
     Learn how to regridding Sentinel-3 SLSTR data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-3</span><span class="tag">climate-change</span>
     </div>
     <a href="/notebooks/Sentinel-3/Regridding_Sentinel_3_SLSTR_LST" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-3 climate-change gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change sentinel-3 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/ESA_EOPF_logo_2025_COLOR_ESA_blue_reduced.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -536,7 +536,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Sentinel-3 Multi-Product Demo with GDAL</strong><br>
     Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">gdal</span>
+      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3_Multi-Product-Demo" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>

--- a/notebooks/gallery-sentinel.md
+++ b/notebooks/gallery-sentinel.md
@@ -609,4 +609,3 @@ Notebooks showcasing Sentinel mission data processing and analysis
   </div>
 </div>
 </div>
-

--- a/notebooks/gallery-sentinel.md
+++ b/notebooks/gallery-sentinel.md
@@ -607,4 +607,3 @@ Notebooks showcasing Sentinel mission data processing and analysis
   </div>
 </div>
 </div>
-

--- a/notebooks/gallery-sentinel.md
+++ b/notebooks/gallery-sentinel.md
@@ -39,7 +39,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <a href="/notebooks/Sentinel-1/Sentinel-1_Soil_moisture" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="gdal sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-1 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -47,7 +47,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Sentinel-1 GRD Geolocation with EOPFZARR Driver</strong><br>
     Ground Control Point (GCP) based geolocation for Sentinel-1 GRD products using the EOPFZARR GDAL driver
     <div style="margin: 6px 0;">
-      <span class="tag">gdal</span><span class="tag">sentinel-1</span>
+      <span class="tag">sentinel-1</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-1/GDAL_Sentinel-1_GCP_Geolocation" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -78,7 +78,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <a href="/notebooks/Sentinel-1/Sentinel-1_L2_OCN_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="gdal sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-1 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -86,7 +86,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Sentinel-1 SLC Burst Selection with EOPFZARR GDAL Driver</strong><br>
     Directly access individual bursts from Sentinel-1 SLC products using the BURST open option
     <div style="margin: 6px 0;">
-      <span class="tag">gdal</span><span class="tag">sentinel-1</span>
+      <span class="tag">sentinel-1</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-1/GDAL_Sentinel-1_SLC_Burst_Selection" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -104,7 +104,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <a href="/notebooks/Sentinel-1/Sentinel-1_L1_SLC_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-1 stac land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -112,12 +112,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>STAC-Based Exploration and Visualization of Sentinel-2 and Sentinel-1 Data</strong><br>
     Learn how to access Sentinel-2 and Sentinel-1 images via the EOPF STAC Catalog using pystac-client
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">land</span><span class="tag">stac</span>
+      <span class="tag">sentinel-1</span><span class="tag">stac</span><span class="tag">land</span>
     </div>
     <a href="/notebooks/STAC/STAC_EOPF_ZARR_SENTINEL" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-1 land xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -125,7 +125,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>xarray EOPF backend - Sentinel-1 Native Mode</strong><br>
     Learn how to access Sentinel-1 products in native mode
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+      <span class="tag">sentinel-1</span><span class="tag">land</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_1_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -135,7 +135,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
 ## Sentinel-2
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -143,12 +143,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Accessing Zarr Data</strong><br>
     Explore how to access Data in Zarr format.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/STAC/Data_Access_Tutorial" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 stac land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="stac land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -156,12 +156,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Analysing snow cover in the Alps using Sentinel-2</strong><br>
     Learn how to use the EOPF Zarr data to analyse snow cover dynamics in the Alps with Sentinel-2 imagery.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">stac</span><span class="tag">land</span>
+      <span class="tag">stac</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_snow_cover_fraction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -169,12 +169,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Building Sentinel-2 Data Cubes with xcube EOPF Data Store</strong><br>
     Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/sentinel_2" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="security xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -182,12 +182,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Deforestation Monitoring using Sentinel 2 and xarray</strong><br>
     Streamlining Cloud-Based Processing with EOPF and Xarray
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">security</span>
+      <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/deforestation_monitoring_zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 openeo land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land stac openeo sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -195,12 +195,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
     Learn how to use the EOPF Zarr data through STAC and openEO
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">openeo</span><span class="tag">land</span><span class="tag">stac</span>
+      <span class="tag">land</span><span class="tag">stac</span><span class="tag">openeo</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/eopf_openeo_stac_remote" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 openeo land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land stac openeo sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -208,12 +208,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
     Learn how to use the EOPF Zarr data through STAC and openEO
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">openeo</span><span class="tag">land</span><span class="tag">stac</span>
+      <span class="tag">land</span><span class="tag">stac</span><span class="tag">openeo</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/eopf_openeo_stac" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 performance" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="performance sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -221,12 +221,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>EOPF zarr Performance Comparison - direct read</strong><br>
     Compare the performance of the Sentinel EOPF zarr format to the SAFE format reading the files directly.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">performance</span>
+      <span class="tag">performance</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/performance/sentinel_performance_zarr_safe_direct" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xcube performance" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="performance xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -234,12 +234,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>EOPF zarr Performance Comparison - xcube</strong><br>
     Compare the performance of the Sentinel EOPF zarr format to the SAFE format using the xcube readers.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">performance</span>
+      <span class="tag">performance</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/performance/sentinel_performance_zarr_safe_xcube" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 land gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="gdal land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -247,12 +247,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Explore EOPF Zarr Sentinel-2 files using GDAL</strong><br>
     Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">land</span><span class="tag">gdal</span>
+      <span class="tag">gdal</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/GDAL_explore_Zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -260,12 +260,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Intoduction to the xarray EOPF backend</strong><br>
     Access and explore analysis-ready and native EOPF Zarr data using xarray
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -273,12 +273,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Introduction to the xcube EOPF Data Store</strong><br>
     Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 climate-change xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -286,12 +286,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>NDSI based snow mapping with Sentinel-2</strong><br>
     Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">xcube</span>
+      <span class="tag">climate-change</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_NDSI_Snow_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -299,12 +299,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>NDVI Time-Series Analysis of Potato Fields</strong><br>
     A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Potato_Field_Crop_Type" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="security xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -312,12 +312,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>NDVI-based approach to study Landslide areas</strong><br>
     Streamlining Cloud-Based Processing with EOPF and Xarray
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">security</span>
+      <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/NDVI_based_landslide_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -325,12 +325,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Parcel delineation using Sentinel-2</strong><br>
     Delineating agricultural parcels based on a neural network, using Sentinel-2 input data
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/parcel_delineation_sentinel" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -338,12 +338,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Random Forest Based Land-Cover Mapping with Sentinel-2</strong><br>
     Demonstrate how to perform a basic land cover mapping using random forest and the Sentinel-2 data in EOPF Zarr format
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Random_Forest_Land_Cover" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -351,7 +351,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Sentinel-2 Crop-Type Classification</strong><br>
     
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/sentinel-2_crop_type_classification_rule-based" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -369,7 +369,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -377,7 +377,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Sentinel-2 L1C MSI Zarr Product Exploration</strong><br>
     Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_MSI_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -395,7 +395,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <a href="/notebooks/Sentinel-2/Sentinel-2_L2A_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -403,12 +403,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Surface Water Level Monitoring with Sentinel-2</strong><br>
     Timeseries of water covered area at Santa Giustina lake, Italy
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">xarray</span>
+      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/water_level_timeseries" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray marine sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -416,12 +416,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Transforming workflow for oceanography study using Sentinel‑2 data, from SAFE to Zarr</strong><br>
     Computing wave spectra with 2D FFT & coherence in the EOPF framework
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">marine</span>
+      <span class="tag">xarray</span><span class="tag">marine</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/oceanographic_wave_spectral_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 climate-change stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change stac sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -429,12 +429,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Wildfire Burn Severity Assessment Using Sentinel-2 L2A Data and dNBR</strong><br>
     A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Gerês wildfire event (Portugal, July 2025).
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">stac</span>
+      <span class="tag">climate-change</span><span class="tag">stac</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_wildfire_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -442,12 +442,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>xarray EOPF backend - Sentinel-2 Analysis Mode</strong><br>
     Learn how to access Sentinel-2 products in analysis mode
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_2_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -455,12 +455,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>xarray EOPF backend - Sentinel-2 Native mode</strong><br>
     Learn how to access Sentinel-2 products in native mode
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_2_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 land gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="gdal land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -468,7 +468,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Zarr vs SAFE Metadata</strong><br>
     Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">land</span><span class="tag">gdal</span>
+      <span class="tag">gdal</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/SAFE_Zarr_Metadata_Comparison_S2_L2A" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -478,7 +478,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
 ## Sentinel-3
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="xcube sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xcube sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -486,12 +486,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Building Sentinel-3 Data Cubes with xcube EOPF Data Store</strong><br>
     Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.
     <div style="margin: 6px 0;">
-      <span class="tag">xcube</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/sentinel_3" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change sentinel-3 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change xarray sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -499,12 +499,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Heatwave in Netherlands</strong><br>
     Learn how to read, process and use Sentinel-3 Land Surface Temperature
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">xarray</span>
+      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/Sentinel-3/Sentinel-3_Heatwave_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="gdal climate-change sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change gdal sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -512,12 +512,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Open Sentinel-3-OLCI-Level-1-EFR Data with GDAL and eopfzarr</strong><br>
     
     <div style="margin: 6px 0;">
-      <span class="tag">gdal</span><span class="tag">climate-change</span><span class="tag">sentinel-3</span>
+      <span class="tag">climate-change</span><span class="tag">gdal</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3-OLCI-Level-1-EFR" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change sentinel-3 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change xarray sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -525,12 +525,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Regridding Sentinel-3 SLSTR Data</strong><br>
     Learn how to regridding Sentinel-3 SLSTR data
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">xarray</span>
+      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/Sentinel-3/Regridding_Sentinel_3_SLSTR_LST" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="gdal climate-change sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change gdal sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/ESA_EOPF_logo_2025_COLOR_ESA_blue_reduced.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -538,7 +538,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>Sentinel-3 Multi-Product Demo with GDAL</strong><br>
     Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver
     <div style="margin: 6px 0;">
-      <span class="tag">gdal</span><span class="tag">climate-change</span><span class="tag">sentinel-3</span>
+      <span class="tag">climate-change</span><span class="tag">gdal</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3_Multi-Product-Demo" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -582,7 +582,7 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <a href="/notebooks/Sentinel-3/Sentinel-3_SLSTR_L2_LST_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray-eopf sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -590,12 +590,12 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>xarray EOPF backend - Sentinel-3 Analysis Mode</strong><br>
     Learn how to access Sentinel-3 products in analysis mode
     <div style="margin: 6px 0;">
-      <span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_3_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray-eopf sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -603,9 +603,10 @@ Notebooks showcasing Sentinel mission data processing and analysis
     <strong>xarray EOPF backend - Sentinel-3 Native Mode</strong><br>
     Learn how to access Sentinel-3 products in native mode
     <div style="margin: 6px 0;">
-      <span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_3_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
 </div>
+

--- a/notebooks/gallery-tools.md
+++ b/notebooks/gallery-tools.md
@@ -553,4 +553,3 @@ Notebooks demonstrating different software tools and libraries
   </div>
 </div>
 </div>
-

--- a/notebooks/gallery-tools.md
+++ b/notebooks/gallery-tools.md
@@ -14,7 +14,7 @@ Notebooks demonstrating different software tools and libraries
 ## Xarray
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -22,12 +22,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Accessing Zarr Data</strong><br>
     Explore how to access Data in Zarr format.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/STAC/Data_Access_Tutorial" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="security xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -35,12 +35,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Deforestation Monitoring using Sentinel 2 and xarray</strong><br>
     Streamlining Cloud-Based Processing with EOPF and Xarray
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">security</span>
+      <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/deforestation_monitoring_zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change sentinel-3 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change xarray sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -48,12 +48,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Heatwave in Netherlands</strong><br>
     Learn how to read, process and use Sentinel-3 Land Surface Temperature
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">xarray</span>
+      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/Sentinel-3/Sentinel-3_Heatwave_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -61,12 +61,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>NDVI Time-Series Analysis of Potato Fields</strong><br>
     A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Potato_Field_Crop_Type" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="security xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -74,12 +74,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>NDVI-based approach to study Landslide areas</strong><br>
     Streamlining Cloud-Based Processing with EOPF and Xarray
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">security</span>
+      <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/NDVI_based_landslide_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -87,7 +87,7 @@ Notebooks demonstrating different software tools and libraries
     <strong>Parcel delineation using Sentinel-2</strong><br>
     Delineating agricultural parcels based on a neural network, using Sentinel-2 input data
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/parcel_delineation_sentinel" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -105,7 +105,7 @@ Notebooks demonstrating different software tools and libraries
     <a href="/notebooks/Sentinel-1/radar_vegetation_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change sentinel-3 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change xarray sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -113,7 +113,7 @@ Notebooks demonstrating different software tools and libraries
     <strong>Regridding Sentinel-3 SLSTR Data</strong><br>
     Learn how to regridding Sentinel-3 SLSTR data
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">xarray</span>
+      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/Sentinel-3/Regridding_Sentinel_3_SLSTR_LST" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -170,7 +170,7 @@ Notebooks demonstrating different software tools and libraries
     <a href="/notebooks/Sentinel-1/Sentinel-1_L1_SLC_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -178,12 +178,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Sentinel-2 Crop-Type Classification</strong><br>
     
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/sentinel-2_crop_type_classification_rule-based" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -191,12 +191,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Sentinel-2 L1C MSI Zarr Product Exploration</strong><br>
     Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_MSI_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -204,12 +204,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Surface Water Level Monitoring with Sentinel-2</strong><br>
     Timeseries of water covered area at Santa Giustina lake, Italy
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">xarray</span>
+      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/water_level_timeseries" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray marine sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -217,7 +217,7 @@ Notebooks demonstrating different software tools and libraries
     <strong>Transforming workflow for oceanography study using Sentinel‑2 data, from SAFE to Zarr</strong><br>
     Computing wave spectra with 2D FFT & coherence in the EOPF framework
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">marine</span>
+      <span class="tag">xarray</span><span class="tag">marine</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/oceanographic_wave_spectral_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -227,7 +227,7 @@ Notebooks demonstrating different software tools and libraries
 ## xarray-eopf plugin
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -235,12 +235,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Intoduction to the xarray EOPF backend</strong><br>
     Access and explore analysis-ready and native EOPF Zarr data using xarray
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-1 land xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -248,12 +248,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>xarray EOPF backend - Sentinel-1 Native Mode</strong><br>
     Learn how to access Sentinel-1 products in native mode
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+      <span class="tag">sentinel-1</span><span class="tag">land</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_1_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -261,12 +261,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>xarray EOPF backend - Sentinel-2 Analysis Mode</strong><br>
     Learn how to access Sentinel-2 products in analysis mode
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_2_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -274,12 +274,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>xarray EOPF backend - Sentinel-2 Native mode</strong><br>
     Learn how to access Sentinel-2 products in native mode
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_2_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray-eopf sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -287,12 +287,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>xarray EOPF backend - Sentinel-3 Analysis Mode</strong><br>
     Learn how to access Sentinel-3 products in analysis mode
     <div style="margin: 6px 0;">
-      <span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_3_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray-eopf sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -300,7 +300,7 @@ Notebooks demonstrating different software tools and libraries
     <strong>xarray EOPF backend - Sentinel-3 Native Mode</strong><br>
     Learn how to access Sentinel-3 products in native mode
     <div style="margin: 6px 0;">
-      <span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_3_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -310,7 +310,7 @@ Notebooks demonstrating different software tools and libraries
 ## xcube-eopf plugin
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -318,12 +318,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Building Sentinel-2 Data Cubes with xcube EOPF Data Store</strong><br>
     Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/sentinel_2" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xcube sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xcube sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -331,12 +331,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Building Sentinel-3 Data Cubes with xcube EOPF Data Store</strong><br>
     Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.
     <div style="margin: 6px 0;">
-      <span class="tag">xcube</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/sentinel_3" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xcube performance" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="performance xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -344,12 +344,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>EOPF zarr Performance Comparison - xcube</strong><br>
     Compare the performance of the Sentinel EOPF zarr format to the SAFE format using the xcube readers.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">performance</span>
+      <span class="tag">performance</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/performance/sentinel_performance_zarr_safe_xcube" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -357,12 +357,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Introduction to the xcube EOPF Data Store</strong><br>
     Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 climate-change xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -370,12 +370,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>NDSI based snow mapping with Sentinel-2</strong><br>
     Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">xcube</span>
+      <span class="tag">climate-change</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_NDSI_Snow_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -383,7 +383,7 @@ Notebooks demonstrating different software tools and libraries
     <strong>Random Forest Based Land-Cover Mapping with Sentinel-2</strong><br>
     Demonstrate how to perform a basic land cover mapping using random forest and the Sentinel-2 data in EOPF Zarr format
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Random_Forest_Land_Cover" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -393,7 +393,7 @@ Notebooks demonstrating different software tools and libraries
 ## GDAL
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="sentinel-2 land gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="gdal land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -401,12 +401,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Explore EOPF Zarr Sentinel-2 files using GDAL</strong><br>
     Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">land</span><span class="tag">gdal</span>
+      <span class="tag">gdal</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/GDAL_explore_Zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="gdal climate-change sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change gdal sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -414,12 +414,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Open Sentinel-3-OLCI-Level-1-EFR Data with GDAL and eopfzarr</strong><br>
     
     <div style="margin: 6px 0;">
-      <span class="tag">gdal</span><span class="tag">climate-change</span><span class="tag">sentinel-3</span>
+      <span class="tag">climate-change</span><span class="tag">gdal</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3-OLCI-Level-1-EFR" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="gdal sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-1 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -427,12 +427,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Sentinel-1 GRD Geolocation with EOPFZARR Driver</strong><br>
     Ground Control Point (GCP) based geolocation for Sentinel-1 GRD products using the EOPFZARR GDAL driver
     <div style="margin: 6px 0;">
-      <span class="tag">gdal</span><span class="tag">sentinel-1</span>
+      <span class="tag">sentinel-1</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-1/GDAL_Sentinel-1_GCP_Geolocation" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="gdal sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-1 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -440,12 +440,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Sentinel-1 SLC Burst Selection with EOPFZARR GDAL Driver</strong><br>
     Directly access individual bursts from Sentinel-1 SLC products using the BURST open option
     <div style="margin: 6px 0;">
-      <span class="tag">gdal</span><span class="tag">sentinel-1</span>
+      <span class="tag">sentinel-1</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-1/GDAL_Sentinel-1_SLC_Burst_Selection" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="gdal climate-change sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change gdal sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/ESA_EOPF_logo_2025_COLOR_ESA_blue_reduced.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -453,12 +453,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Sentinel-3 Multi-Product Demo with GDAL</strong><br>
     Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver
     <div style="margin: 6px 0;">
-      <span class="tag">gdal</span><span class="tag">climate-change</span><span class="tag">sentinel-3</span>
+      <span class="tag">climate-change</span><span class="tag">gdal</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3_Multi-Product-Demo" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 land gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="gdal land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -466,7 +466,7 @@ Notebooks demonstrating different software tools and libraries
     <strong>Zarr vs SAFE Metadata</strong><br>
     Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">land</span><span class="tag">gdal</span>
+      <span class="tag">gdal</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/SAFE_Zarr_Metadata_Comparison_S2_L2A" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -476,7 +476,7 @@ Notebooks demonstrating different software tools and libraries
 ## STAC
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="sentinel-2 stac land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="stac land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -484,12 +484,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Analysing snow cover in the Alps using Sentinel-2</strong><br>
     Learn how to use the EOPF Zarr data to analyse snow cover dynamics in the Alps with Sentinel-2 imagery.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">stac</span><span class="tag">land</span>
+      <span class="tag">stac</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_snow_cover_fraction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 openeo land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land stac openeo sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -497,12 +497,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
     Learn how to use the EOPF Zarr data through STAC and openEO
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">openeo</span><span class="tag">land</span><span class="tag">stac</span>
+      <span class="tag">land</span><span class="tag">stac</span><span class="tag">openeo</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/eopf_openeo_stac_remote" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 openeo land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land stac openeo sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -510,7 +510,7 @@ Notebooks demonstrating different software tools and libraries
     <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
     Learn how to use the EOPF Zarr data through STAC and openEO
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">openeo</span><span class="tag">land</span><span class="tag">stac</span>
+      <span class="tag">land</span><span class="tag">stac</span><span class="tag">openeo</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/eopf_openeo_stac" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -528,7 +528,7 @@ Notebooks demonstrating different software tools and libraries
     <a href="/notebooks/Sentinel-2/oil_spill_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-1 stac land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -536,12 +536,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>STAC-Based Exploration and Visualization of Sentinel-2 and Sentinel-1 Data</strong><br>
     Learn how to access Sentinel-2 and Sentinel-1 images via the EOPF STAC Catalog using pystac-client
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">land</span><span class="tag">stac</span>
+      <span class="tag">sentinel-1</span><span class="tag">stac</span><span class="tag">land</span>
     </div>
     <a href="/notebooks/STAC/STAC_EOPF_ZARR_SENTINEL" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 climate-change stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change stac sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -549,9 +549,10 @@ Notebooks demonstrating different software tools and libraries
     <strong>Wildfire Burn Severity Assessment Using Sentinel-2 L2A Data and dNBR</strong><br>
     A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Gerês wildfire event (Portugal, July 2025).
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">stac</span>
+      <span class="tag">climate-change</span><span class="tag">stac</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_wildfire_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
 </div>
+

--- a/notebooks/gallery-tools.md
+++ b/notebooks/gallery-tools.md
@@ -555,4 +555,3 @@ Notebooks demonstrating different software tools and libraries
   </div>
 </div>
 </div>
-

--- a/notebooks/gallery-tools.md
+++ b/notebooks/gallery-tools.md
@@ -14,15 +14,15 @@ Notebooks demonstrating different software tools and libraries
 ## Xarray
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Accessing Zarr Data</strong><br>
-    Explore how to access Data in Zarr format.
+    Explore how to access Data in Zarr format.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/STAC/Data_Access_Tutorial" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -33,35 +33,35 @@ Notebooks demonstrating different software tools and libraries
   </div>
   <div style="flex: 1;">
     <strong>Deforestation Monitoring using Sentinel 2 and xarray</strong><br>
-    Streamlining Cloud-Based Processing with EOPF and Xarray
+    Streamlining Cloud-Based Processing with EOPF and Xarray<br>
     <div style="margin: 6px 0;">
       <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/deforestation_monitoring_zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change xarray sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Heatwave in Netherlands</strong><br>
-    Learn how to read, process and use Sentinel-3 Land Surface Temperature
+    Learn how to read, process and use Sentinel-3 Land Surface Temperature<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-3/Sentinel-3_Heatwave_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>NDVI Time-Series Analysis of Potato Fields</strong><br>
-    A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.
+    A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Potato_Field_Crop_Type" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -72,152 +72,151 @@ Notebooks demonstrating different software tools and libraries
   </div>
   <div style="flex: 1;">
     <strong>NDVI-based approach to study Landslide areas</strong><br>
-    Streamlining Cloud-Based Processing with EOPF and Xarray
+    Streamlining Cloud-Based Processing with EOPF and Xarray<br>
     <div style="margin: 6px 0;">
       <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/NDVI_based_landslide_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Parcel delineation using Sentinel-2</strong><br>
-    Delineating agricultural parcels based on a neural network, using Sentinel-2 input data
+    Delineating agricultural parcels based on a neural network, using Sentinel-2 input data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/parcel_delineation_sentinel" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Radar Vegetation Index</strong><br>
-    Monitor vegetation crop growth using Sentinel-1 GRD data
+    Monitor vegetation crop growth using Sentinel-1 GRD data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-1/radar_vegetation_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change xarray sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Regridding Sentinel-3 SLSTR Data</strong><br>
-    Learn how to regridding Sentinel-3 SLSTR data
+    Learn how to regridding Sentinel-3 SLSTR data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-3/Regridding_Sentinel_3_SLSTR_LST" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel 1 Surface Soil Moisture (SSM)</strong><br>
-    Learn how to compute surface soil moisture from Sentinel-1 data
+    Learn how to compute surface soil moisture from Sentinel-1 data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_Soil_moisture" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-1 GRD Zarr Product Exploration</strong><br>
-    Explore how to open, inspect the metadata and visualise Sentinel-1 GRD Zarr format
+    Explore how to open, inspect the metadata and visualise Sentinel-1 GRD Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L1_GRD_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="marine sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-1 L2 OCN Zarr Product Exploration</strong><br>
-    Explore how to open, visualise and use Sentinel-1 OCN products in EOPF Zarr format
+    Explore how to open, visualise and use Sentinel-1 OCN products in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">marine</span>
+      <span class="tag">marine</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L2_OCN_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-1 SLC Zarr Product Exploration</strong><br>
-    Explore how to open, inspect the metadata and process Sentinel-1 Single Look Complex (SLC) Zarr format
+    Explore how to open, inspect the metadata and process Sentinel-1 Single Look Complex (SLC) Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L1_SLC_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-2 Crop-Type Classification</strong><br>
-    
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/sentinel-2_crop_type_classification_rule-based" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-2 L1C MSI Zarr Product Exploration</strong><br>
-    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
+    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_MSI_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray climate-change sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Surface Water Level Monitoring with Sentinel-2</strong><br>
-    Timeseries of water covered area at Santa Giustina lake, Italy
+    Timeseries of water covered area at Santa Giustina lake, Italy<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">climate-change</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/water_level_timeseries" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray marine sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="marine xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Transforming workflow for oceanography study using Sentinel‑2 data, from SAFE to Zarr</strong><br>
-    Computing wave spectra with 2D FFT & coherence in the EOPF framework
+    Computing wave spectra with 2D FFT & coherence in the EOPF framework<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">marine</span><span class="tag">sentinel-2</span>
+      <span class="tag">marine</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/oceanographic_wave_spectral_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -233,22 +232,22 @@ Notebooks demonstrating different software tools and libraries
   </div>
   <div style="flex: 1;">
     <strong>Intoduction to the xarray EOPF backend</strong><br>
-    Access and explore analysis-ready and native EOPF Zarr data using xarray
+    Access and explore analysis-ready and native EOPF Zarr data using xarray<br>
     <div style="margin: 6px 0;">
       <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 land xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>xarray EOPF backend - Sentinel-1 Native Mode</strong><br>
-    Learn how to access Sentinel-1 products in native mode
+    Learn how to access Sentinel-1 products in native mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">land</span><span class="tag">xarray-eopf</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_1_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -259,7 +258,7 @@ Notebooks demonstrating different software tools and libraries
   </div>
   <div style="flex: 1;">
     <strong>xarray EOPF backend - Sentinel-2 Analysis Mode</strong><br>
-    Learn how to access Sentinel-2 products in analysis mode
+    Learn how to access Sentinel-2 products in analysis mode<br>
     <div style="margin: 6px 0;">
       <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
@@ -272,35 +271,35 @@ Notebooks demonstrating different software tools and libraries
   </div>
   <div style="flex: 1;">
     <strong>xarray EOPF backend - Sentinel-2 Native mode</strong><br>
-    Learn how to access Sentinel-2 products in native mode
+    Learn how to access Sentinel-2 products in native mode<br>
     <div style="margin: 6px 0;">
       <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_2_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-3 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>xarray EOPF backend - Sentinel-3 Analysis Mode</strong><br>
-    Learn how to access Sentinel-3 products in analysis mode
+    Learn how to access Sentinel-3 products in analysis mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span>
+      <span class="tag">land</span><span class="tag">sentinel-3</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_3_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-3 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>xarray EOPF backend - Sentinel-3 Native Mode</strong><br>
-    Learn how to access Sentinel-3 products in native mode
+    Learn how to access Sentinel-3 products in native mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span>
+      <span class="tag">land</span><span class="tag">sentinel-3</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_3_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -310,80 +309,80 @@ Notebooks demonstrating different software tools and libraries
 ## xcube-eopf plugin
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Building Sentinel-2 Data Cubes with xcube EOPF Data Store</strong><br>
-    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.
+    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/sentinel_2" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xcube sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-3 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Building Sentinel-3 Data Cubes with xcube EOPF Data Store</strong><br>
-    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.
+    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-3</span>
+      <span class="tag">land</span><span class="tag">sentinel-3</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/sentinel_3" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="performance xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-2 performance xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>EOPF zarr Performance Comparison - xcube</strong><br>
-    Compare the performance of the Sentinel EOPF zarr format to the SAFE format using the xcube readers.
+    Compare the performance of the Sentinel EOPF zarr format to the SAFE format using the xcube readers.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">performance</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
+      <span class="tag">sentinel-2</span><span class="tag">performance</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/performance/sentinel_performance_zarr_safe_xcube" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Introduction to the xcube EOPF Data Store</strong><br>
-    Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.
+    Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change sentinel-2 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>NDSI based snow mapping with Sentinel-2</strong><br>
-    Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format
+    Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
+      <span class="tag">climate-change</span><span class="tag">sentinel-2</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_NDSI_Snow_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Random Forest Based Land-Cover Mapping with Sentinel-2</strong><br>
-    Demonstrate how to perform a basic land cover mapping using random forest and the Sentinel-2 data in EOPF Zarr format
+    Demonstrate how to perform a basic land cover mapping using random forest and the Sentinel-2 data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/Sentinel-2/Random_Forest_Land_Cover" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -393,28 +392,27 @@ Notebooks demonstrating different software tools and libraries
 ## GDAL
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="gdal land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land gdal sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Explore EOPF Zarr Sentinel-2 files using GDAL</strong><br>
-    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
+    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">gdal</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">gdal</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/GDAL_explore_Zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change gdal sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 climate-change gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Open Sentinel-3-OLCI-Level-1-EFR Data with GDAL and eopfzarr</strong><br>
-    
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">gdal</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3-OLCI-Level-1-EFR" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -425,7 +423,7 @@ Notebooks demonstrating different software tools and libraries
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-1 GRD Geolocation with EOPFZARR Driver</strong><br>
-    Ground Control Point (GCP) based geolocation for Sentinel-1 GRD products using the EOPFZARR GDAL driver
+    Ground Control Point (GCP) based geolocation for Sentinel-1 GRD products using the EOPFZARR GDAL driver<br>
     <div style="margin: 6px 0;">
       <span class="tag">sentinel-1</span><span class="tag">gdal</span>
     </div>
@@ -438,35 +436,35 @@ Notebooks demonstrating different software tools and libraries
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-1 SLC Burst Selection with EOPFZARR GDAL Driver</strong><br>
-    Directly access individual bursts from Sentinel-1 SLC products using the BURST open option
+    Directly access individual bursts from Sentinel-1 SLC products using the BURST open option<br>
     <div style="margin: 6px 0;">
       <span class="tag">sentinel-1</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-1/GDAL_Sentinel-1_SLC_Burst_Selection" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change gdal sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 climate-change gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/ESA_EOPF_logo_2025_COLOR_ESA_blue_reduced.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-3 Multi-Product Demo with GDAL</strong><br>
-    Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver
+    Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">gdal</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3_Multi-Product-Demo" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="gdal land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land gdal sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Zarr vs SAFE Metadata</strong><br>
-    Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)
+    Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)<br>
     <div style="margin: 6px 0;">
-      <span class="tag">gdal</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">gdal</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/SAFE_Zarr_Metadata_Comparison_S2_L2A" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -476,41 +474,41 @@ Notebooks demonstrating different software tools and libraries
 ## STAC
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="stac land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land stac sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Analysing snow cover in the Alps using Sentinel-2</strong><br>
-    Learn how to use the EOPF Zarr data to analyse snow cover dynamics in the Alps with Sentinel-2 imagery.
+    Learn how to use the EOPF Zarr data to analyse snow cover dynamics in the Alps with Sentinel-2 imagery.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">stac</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">stac</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_snow_cover_fraction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land stac openeo sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land openeo stac sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
-    Learn how to use the EOPF Zarr data through STAC and openEO
+    Learn how to use the EOPF Zarr data through STAC and openEO<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">stac</span><span class="tag">openeo</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">openeo</span><span class="tag">stac</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/eopf_openeo_stac_remote" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land stac openeo sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land openeo stac sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
-    Learn how to use the EOPF Zarr data through STAC and openEO
+    Learn how to use the EOPF Zarr data through STAC and openEO<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">stac</span><span class="tag">openeo</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">openeo</span><span class="tag">stac</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/eopf_openeo_stac" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -521,37 +519,38 @@ Notebooks demonstrating different software tools and libraries
   </div>
   <div style="flex: 1;">
     <strong>OSI - Oil Spill Index</strong><br>
-    Learn how to use the Oil Spill Index (OSI) to detect oil spills using Sentine-2 data.
+    Learn how to use the Oil Spill Index (OSI) to detect oil spills using Sentine-2 data.<br>
     <div style="margin: 6px 0;">
       <span class="tag">sentinel 2</span><span class="tag">stac</span><span class="tag">marine</span>
     </div>
     <a href="/notebooks/Sentinel-2/oil_spill_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 stac land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land stac sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>STAC-Based Exploration and Visualization of Sentinel-2 and Sentinel-1 Data</strong><br>
-    Learn how to access Sentinel-2 and Sentinel-1 images via the EOPF STAC Catalog using pystac-client
+    Learn how to access Sentinel-2 and Sentinel-1 images via the EOPF STAC Catalog using pystac-client<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">stac</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">stac</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/STAC/STAC_EOPF_ZARR_SENTINEL" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change stac sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="stac climate-change sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Wildfire Burn Severity Assessment Using Sentinel-2 L2A Data and dNBR</strong><br>
-    A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Gerês wildfire event (Portugal, July 2025).
+    A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Gerês wildfire event (Portugal, July 2025).<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">stac</span><span class="tag">sentinel-2</span>
+      <span class="tag">stac</span><span class="tag">climate-change</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_wildfire_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
 </div>
+

--- a/notebooks/gallery-tools.md
+++ b/notebooks/gallery-tools.md
@@ -13,8 +13,8 @@ Notebooks demonstrating different software tools and libraries
 
 ## Xarray
 
-<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px; margin-bottom: 40px;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -22,12 +22,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Accessing Zarr Data</strong><br>
     Explore how to access Data in Zarr format.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/STAC/Data_Access_Tutorial" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="security xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-2 security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -35,12 +35,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Deforestation Monitoring using Sentinel 2 and xarray</strong><br>
     Streamlining Cloud-Based Processing with EOPF and Xarray<br>
     <div style="margin: 6px 0;">
-      <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-2</span><span class="tag">security</span>
     </div>
     <a href="/notebooks/Sentinel-2/deforestation_monitoring_zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-3 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-3 climate-change" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -48,12 +48,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Heatwave in Netherlands</strong><br>
     Learn how to read, process and use Sentinel-3 Land Surface Temperature<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-3</span><span class="tag">climate-change</span>
     </div>
     <a href="/notebooks/Sentinel-3/Sentinel-3_Heatwave_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -61,12 +61,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>NDVI Time-Series Analysis of Potato Fields</strong><br>
     A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Potato_Field_Crop_Type" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="security xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-2 security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -74,12 +74,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>NDVI-based approach to study Landslide areas</strong><br>
     Streamlining Cloud-Based Processing with EOPF and Xarray<br>
     <div style="margin: 6px 0;">
-      <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-2</span><span class="tag">security</span>
     </div>
     <a href="/notebooks/Sentinel-2/NDVI_based_landslide_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -87,12 +87,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Parcel delineation using Sentinel-2</strong><br>
     Delineating agricultural parcels based on a neural network, using Sentinel-2 input data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/parcel_delineation_sentinel" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -100,12 +100,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Radar Vegetation Index</strong><br>
     Monitor vegetation crop growth using Sentinel-1 GRD data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/Sentinel-1/radar_vegetation_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-3 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-3 climate-change" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -113,12 +113,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Regridding Sentinel-3 SLSTR Data</strong><br>
     Learn how to regridding Sentinel-3 SLSTR data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-3</span><span class="tag">climate-change</span>
     </div>
     <a href="/notebooks/Sentinel-3/Regridding_Sentinel_3_SLSTR_LST" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -126,12 +126,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Sentinel 1 Surface Soil Moisture (SSM)</strong><br>
     Learn how to compute surface soil moisture from Sentinel-1 data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_Soil_moisture" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -139,12 +139,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Sentinel-1 GRD Zarr Product Exploration</strong><br>
     Explore how to open, inspect the metadata and visualise Sentinel-1 GRD Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L1_GRD_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="marine sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-1 marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -152,12 +152,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Sentinel-1 L2 OCN Zarr Product Exploration</strong><br>
     Explore how to open, visualise and use Sentinel-1 OCN products in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">marine</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-1</span><span class="tag">marine</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L2_OCN_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -165,24 +165,24 @@ Notebooks demonstrating different software tools and libraries
     <strong>Sentinel-1 SLC Zarr Product Exploration</strong><br>
     Explore how to open, inspect the metadata and process Sentinel-1 Single Look Complex (SLC) Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L1_SLC_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-2 Crop-Type Classification</strong><br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/sentinel-2_crop_type_classification_rule-based" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -190,12 +190,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Sentinel-2 L1C MSI Zarr Product Exploration</strong><br>
     Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_MSI_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray climate-change sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-2 climate-change" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -203,12 +203,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Surface Water Level Monitoring with Sentinel-2</strong><br>
     Timeseries of water covered area at Santa Giustina lake, Italy<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">climate-change</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-2</span><span class="tag">climate-change</span>
     </div>
     <a href="/notebooks/Sentinel-2/water_level_timeseries" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="marine xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-2 marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -216,7 +216,7 @@ Notebooks demonstrating different software tools and libraries
     <strong>Transforming workflow for oceanography study using Sentinel‑2 data, from SAFE to Zarr</strong><br>
     Computing wave spectra with 2D FFT & coherence in the EOPF framework<br>
     <div style="margin: 6px 0;">
-      <span class="tag">marine</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-2</span><span class="tag">marine</span>
     </div>
     <a href="/notebooks/Sentinel-2/oceanographic_wave_spectral_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -225,8 +225,8 @@ Notebooks demonstrating different software tools and libraries
 
 ## xarray-eopf plugin
 
-<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px; margin-bottom: 40px;">
+<div class="notebook-card" data-tags="land sentinel-2 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -234,12 +234,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Intoduction to the xarray EOPF backend</strong><br>
     Access and explore analysis-ready and native EOPF Zarr data using xarray<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-1 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -247,12 +247,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>xarray EOPF backend - Sentinel-1 Native Mode</strong><br>
     Learn how to access Sentinel-1 products in native mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-1</span>
+      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_1_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -260,12 +260,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>xarray EOPF backend - Sentinel-2 Analysis Mode</strong><br>
     Learn how to access Sentinel-2 products in analysis mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_2_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -273,7 +273,7 @@ Notebooks demonstrating different software tools and libraries
     <strong>xarray EOPF backend - Sentinel-2 Native mode</strong><br>
     Learn how to access Sentinel-2 products in native mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_2_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -308,7 +308,7 @@ Notebooks demonstrating different software tools and libraries
 
 ## xcube-eopf plugin
 
-<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px; margin-bottom: 40px;">
 <div class="notebook-card" data-tags="land sentinel-2 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
@@ -361,7 +361,7 @@ Notebooks demonstrating different software tools and libraries
     <a href="/notebooks/xcube_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change sentinel-2 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-2 climate-change xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -369,7 +369,7 @@ Notebooks demonstrating different software tools and libraries
     <strong>NDSI based snow mapping with Sentinel-2</strong><br>
     Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">sentinel-2</span><span class="tag">xcube</span>
+      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_NDSI_Snow_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -391,8 +391,8 @@ Notebooks demonstrating different software tools and libraries
 
 ## GDAL
 
-<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="land gdal sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px; margin-bottom: 40px;">
+<div class="notebook-card" data-tags="land sentinel-2 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -400,24 +400,24 @@ Notebooks demonstrating different software tools and libraries
     <strong>Explore EOPF Zarr Sentinel-2 files using GDAL</strong><br>
     Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">gdal</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-2/GDAL_explore_Zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-3 climate-change gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change sentinel-3 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Open Sentinel-3-OLCI-Level-1-EFR Data with GDAL and eopfzarr</strong><br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">gdal</span>
+      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3-OLCI-Level-1-EFR" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="gdal sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -425,12 +425,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Sentinel-1 GRD Geolocation with EOPFZARR Driver</strong><br>
     Ground Control Point (GCP) based geolocation for Sentinel-1 GRD products using the EOPFZARR GDAL driver<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">gdal</span>
+      <span class="tag">gdal</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/Sentinel-1/GDAL_Sentinel-1_GCP_Geolocation" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="gdal sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -438,12 +438,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Sentinel-1 SLC Burst Selection with EOPFZARR GDAL Driver</strong><br>
     Directly access individual bursts from Sentinel-1 SLC products using the BURST open option<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">gdal</span>
+      <span class="tag">gdal</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/Sentinel-1/GDAL_Sentinel-1_SLC_Burst_Selection" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-3 climate-change gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change sentinel-3 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/ESA_EOPF_logo_2025_COLOR_ESA_blue_reduced.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -451,12 +451,12 @@ Notebooks demonstrating different software tools and libraries
     <strong>Sentinel-3 Multi-Product Demo with GDAL</strong><br>
     Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">gdal</span>
+      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3_Multi-Product-Demo" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land gdal sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -464,7 +464,7 @@ Notebooks demonstrating different software tools and libraries
     <strong>Zarr vs SAFE Metadata</strong><br>
     Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">gdal</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-2/SAFE_Zarr_Metadata_Comparison_S2_L2A" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -473,7 +473,7 @@ Notebooks demonstrating different software tools and libraries
 
 ## STAC
 
-<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px; margin-bottom: 40px;">
 <div class="notebook-card" data-tags="land stac sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
@@ -513,7 +513,7 @@ Notebooks demonstrating different software tools and libraries
     <a href="/notebooks/Sentinel-2/eopf_openeo_stac" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel 2 stac marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="stac marine sentinel 2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -521,7 +521,7 @@ Notebooks demonstrating different software tools and libraries
     <strong>OSI - Oil Spill Index</strong><br>
     Learn how to use the Oil Spill Index (OSI) to detect oil spills using Sentine-2 data.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel 2</span><span class="tag">stac</span><span class="tag">marine</span>
+      <span class="tag">stac</span><span class="tag">marine</span><span class="tag">sentinel 2</span>
     </div>
     <a href="/notebooks/Sentinel-2/oil_spill_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -539,7 +539,7 @@ Notebooks demonstrating different software tools and libraries
     <a href="/notebooks/STAC/STAC_EOPF_ZARR_SENTINEL" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="stac climate-change sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="stac sentinel-2 climate-change" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -547,7 +547,7 @@ Notebooks demonstrating different software tools and libraries
     <strong>Wildfire Burn Severity Assessment Using Sentinel-2 L2A Data and dNBR</strong><br>
     A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Gerês wildfire event (Portugal, July 2025).<br>
     <div style="margin: 6px 0;">
-      <span class="tag">stac</span><span class="tag">climate-change</span><span class="tag">sentinel-2</span>
+      <span class="tag">stac</span><span class="tag">sentinel-2</span><span class="tag">climate-change</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_wildfire_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>

--- a/notebooks/gallery-tools.md
+++ b/notebooks/gallery-tools.md
@@ -13,35 +13,546 @@ Notebooks demonstrating different software tools and libraries
 
 ## Xarray
 
-```{gallery-grid}
-:category: xarray
-:columns: 1 1 2 3
-```
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Accessing Zarr Data</strong><br>
+    Explore how to access Data in Zarr format.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/STAC/Data_Access_Tutorial" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Deforestation Monitoring using Sentinel 2 and xarray</strong><br>
+    Streamlining Cloud-Based Processing with EOPF and Xarray
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">security</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/deforestation_monitoring_zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="climate-change sentinel-3 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Heatwave in Netherlands</strong><br>
+    Learn how to read, process and use Sentinel-3 Land Surface Temperature
+    <div style="margin: 6px 0;">
+      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">xarray</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/Sentinel-3_Heatwave_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>NDVI Time-Series Analysis of Potato Fields</strong><br>
+    A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Potato_Field_Crop_Type" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>NDVI-based approach to study Landslide areas</strong><br>
+    Streamlining Cloud-Based Processing with EOPF and Xarray
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">security</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/NDVI_based_landslide_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Parcel delineation using Sentinel-2</strong><br>
+    Delineating agricultural parcels based on a neural network, using Sentinel-2 input data
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/parcel_delineation_sentinel" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Radar Vegetation Index</strong><br>
+    Monitor vegetation crop growth using Sentinel-1 GRD data
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/radar_vegetation_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="climate-change sentinel-3 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Regridding Sentinel-3 SLSTR Data</strong><br>
+    Learn how to regridding Sentinel-3 SLSTR data
+    <div style="margin: 6px 0;">
+      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">xarray</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/Regridding_Sentinel_3_SLSTR_LST" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel 1 Surface Soil Moisture (SSM)</strong><br>
+    Learn how to compute surface soil moisture from Sentinel-1 data
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/Sentinel-1_Soil_moisture" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-1 GRD Zarr Product Exploration</strong><br>
+    Explore how to open, inspect the metadata and visualise Sentinel-1 GRD Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/Sentinel-1_L1_GRD_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-1 L2 OCN Zarr Product Exploration</strong><br>
+    Explore how to open, visualise and use Sentinel-1 OCN products in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">marine</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/Sentinel-1_L2_OCN_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-1 SLC Zarr Product Exploration</strong><br>
+    Explore how to open, inspect the metadata and process Sentinel-1 Single Look Complex (SLC) Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/Sentinel-1_L1_SLC_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-2 Crop-Type Classification</strong><br>
+    
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/sentinel-2_crop_type_classification_rule-based" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-2 L1C MSI Zarr Product Exploration</strong><br>
+    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_MSI_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Surface Water Level Monitoring with Sentinel-2</strong><br>
+    Timeseries of water covered area at Santa Giustina lake, Italy
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">xarray</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/water_level_timeseries" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Transforming workflow for oceanography study using Sentinel‑2 data, from SAFE to Zarr</strong><br>
+    Computing wave spectra with 2D FFT & coherence in the EOPF framework
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">marine</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/oceanographic_wave_spectral_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+</div>
 
 ## xarray-eopf plugin
 
-```{gallery-grid}
-:category: xarray-eopf
-:columns: 1 1 2 3
-```
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Intoduction to the xarray EOPF backend</strong><br>
+    Access and explore analysis-ready and native EOPF Zarr data using xarray
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>xarray EOPF backend - Sentinel-1 Native Mode</strong><br>
+    Learn how to access Sentinel-1 products in native mode
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/sentinel_1_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>xarray EOPF backend - Sentinel-2 Analysis Mode</strong><br>
+    Learn how to access Sentinel-2 products in analysis mode
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/sentinel_2_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>xarray EOPF backend - Sentinel-2 Native mode</strong><br>
+    Learn how to access Sentinel-2 products in native mode
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/sentinel_2_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="xarray-eopf sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>xarray EOPF backend - Sentinel-3 Analysis Mode</strong><br>
+    Learn how to access Sentinel-3 products in analysis mode
+    <div style="margin: 6px 0;">
+      <span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/sentinel_3_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="xarray-eopf sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>xarray EOPF backend - Sentinel-3 Native Mode</strong><br>
+    Learn how to access Sentinel-3 products in native mode
+    <div style="margin: 6px 0;">
+      <span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/sentinel_3_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+</div>
 
 ## xcube-eopf plugin
 
-```{gallery-grid}
-:category: xcube
-:columns: 1 1 2 3
-```
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Building Sentinel-2 Data Cubes with xcube EOPF Data Store</strong><br>
+    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xcube_eopf_plugin/sentinel_2" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="xcube sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Building Sentinel-3 Data Cubes with xcube EOPF Data Store</strong><br>
+    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.
+    <div style="margin: 6px 0;">
+      <span class="tag">xcube</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xcube_eopf_plugin/sentinel_3" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xcube performance" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>EOPF zarr Performance Comparison - xcube</strong><br>
+    Compare the performance of the Sentinel EOPF zarr format to the SAFE format using the xcube readers.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">performance</span>
+    </div>
+    <a href="/notebooks/performance/sentinel_performance_zarr_safe_xcube" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Introduction to the xcube EOPF Data Store</strong><br>
+    Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xcube_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 climate-change xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>NDSI based snow mapping with Sentinel-2</strong><br>
+    Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">xcube</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Sentinel-2_NDSI_Snow_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Random Forest Based Land-Cover Mapping with Sentinel-2</strong><br>
+    Demonstrate how to perform a basic land cover mapping using random forest and the Sentinel-2 data in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Random_Forest_Land_Cover" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+</div>
 
 ## GDAL
 
-```{gallery-grid}
-:category: gdal
-:columns: 1 1 2 3
-```
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div class="notebook-card" data-tags="sentinel-2 land gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Explore EOPF Zarr Sentinel-2 files using GDAL</strong><br>
+    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">land</span><span class="tag">gdal</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/GDAL_explore_Zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="gdal climate-change sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Open Sentinel-3-OLCI-Level-1-EFR Data with GDAL and eopfzarr</strong><br>
+    
+    <div style="margin: 6px 0;">
+      <span class="tag">gdal</span><span class="tag">climate-change</span><span class="tag">sentinel-3</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3-OLCI-Level-1-EFR" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="gdal sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-1 GRD Geolocation with EOPFZARR Driver</strong><br>
+    Ground Control Point (GCP) based geolocation for Sentinel-1 GRD products using the EOPFZARR GDAL driver
+    <div style="margin: 6px 0;">
+      <span class="tag">gdal</span><span class="tag">sentinel-1</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/GDAL_Sentinel-1_GCP_Geolocation" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="gdal sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-1 SLC Burst Selection with EOPFZARR GDAL Driver</strong><br>
+    Directly access individual bursts from Sentinel-1 SLC products using the BURST open option
+    <div style="margin: 6px 0;">
+      <span class="tag">gdal</span><span class="tag">sentinel-1</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/GDAL_Sentinel-1_SLC_Burst_Selection" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="gdal climate-change sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/ESA_EOPF_logo_2025_COLOR_ESA_blue_reduced.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-3 Multi-Product Demo with GDAL</strong><br>
+    Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver
+    <div style="margin: 6px 0;">
+      <span class="tag">gdal</span><span class="tag">climate-change</span><span class="tag">sentinel-3</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3_Multi-Product-Demo" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 land gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Zarr vs SAFE Metadata</strong><br>
+    Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">land</span><span class="tag">gdal</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/SAFE_Zarr_Metadata_Comparison_S2_L2A" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+</div>
 
 ## STAC
 
-```{gallery-grid}
-:category: stac
-:columns: 1 1 2 3
-```
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div class="notebook-card" data-tags="sentinel-2 stac land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Analysing snow cover in the Alps using Sentinel-2</strong><br>
+    Learn how to use the EOPF Zarr data to analyse snow cover dynamics in the Alps with Sentinel-2 imagery.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">stac</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Sentinel-2_snow_cover_fraction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 openeo land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
+    Learn how to use the EOPF Zarr data through STAC and openEO
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">openeo</span><span class="tag">land</span><span class="tag">stac</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/eopf_openeo_stac_remote" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 openeo land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
+    Learn how to use the EOPF Zarr data through STAC and openEO
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">openeo</span><span class="tag">land</span><span class="tag">stac</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/eopf_openeo_stac" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel 2 stac marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>OSI - Oil Spill Index</strong><br>
+    Learn how to use the Oil Spill Index (OSI) to detect oil spills using Sentine-2 data.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel 2</span><span class="tag">stac</span><span class="tag">marine</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/oil_spill_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>STAC-Based Exploration and Visualization of Sentinel-2 and Sentinel-1 Data</strong><br>
+    Learn how to access Sentinel-2 and Sentinel-1 images via the EOPF STAC Catalog using pystac-client
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">land</span><span class="tag">stac</span>
+    </div>
+    <a href="/notebooks/STAC/STAC_EOPF_ZARR_SENTINEL" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 climate-change stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Wildfire Burn Severity Assessment Using Sentinel-2 L2A Data and dNBR</strong><br>
+    A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Gerês wildfire event (Portugal, July 2025).
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">stac</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Sentinel-2_wildfire_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+</div>
+

--- a/notebooks/gallery-topics.md
+++ b/notebooks/gallery-topics.md
@@ -14,93 +14,93 @@ Notebooks organized by Earth observation application domains
 ## Land Applications
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Accessing Zarr Data</strong><br>
-    Explore how to access Data in Zarr format.
+    Explore how to access Data in Zarr format.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/STAC/Data_Access_Tutorial" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="stac land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land stac sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Analysing snow cover in the Alps using Sentinel-2</strong><br>
-    Learn how to use the EOPF Zarr data to analyse snow cover dynamics in the Alps with Sentinel-2 imagery.
+    Learn how to use the EOPF Zarr data to analyse snow cover dynamics in the Alps with Sentinel-2 imagery.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">stac</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">stac</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_snow_cover_fraction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Building Sentinel-2 Data Cubes with xcube EOPF Data Store</strong><br>
-    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.
+    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/sentinel_2" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xcube sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-3 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Building Sentinel-3 Data Cubes with xcube EOPF Data Store</strong><br>
-    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.
+    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-3</span>
+      <span class="tag">land</span><span class="tag">sentinel-3</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/sentinel_3" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land stac openeo sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land openeo stac sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
-    Learn how to use the EOPF Zarr data through STAC and openEO
+    Learn how to use the EOPF Zarr data through STAC and openEO<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">stac</span><span class="tag">openeo</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">openeo</span><span class="tag">stac</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/eopf_openeo_stac_remote" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land stac openeo sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land openeo stac sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
-    Learn how to use the EOPF Zarr data through STAC and openEO
+    Learn how to use the EOPF Zarr data through STAC and openEO<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">stac</span><span class="tag">openeo</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">openeo</span><span class="tag">stac</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/eopf_openeo_stac" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="gdal land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land gdal sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Explore EOPF Zarr Sentinel-2 files using GDAL</strong><br>
-    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
+    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">gdal</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">gdal</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/GDAL_explore_Zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -111,165 +111,164 @@ Notebooks organized by Earth observation application domains
   </div>
   <div style="flex: 1;">
     <strong>Intoduction to the xarray EOPF backend</strong><br>
-    Access and explore analysis-ready and native EOPF Zarr data using xarray
+    Access and explore analysis-ready and native EOPF Zarr data using xarray<br>
     <div style="margin: 6px 0;">
       <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Introduction to the xcube EOPF Data Store</strong><br>
-    Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.
+    Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>NDVI Time-Series Analysis of Potato Fields</strong><br>
-    A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.
+    A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Potato_Field_Crop_Type" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Parcel delineation using Sentinel-2</strong><br>
-    Delineating agricultural parcels based on a neural network, using Sentinel-2 input data
+    Delineating agricultural parcels based on a neural network, using Sentinel-2 input data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/parcel_delineation_sentinel" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Radar Vegetation Index</strong><br>
-    Monitor vegetation crop growth using Sentinel-1 GRD data
+    Monitor vegetation crop growth using Sentinel-1 GRD data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-1/radar_vegetation_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Random Forest Based Land-Cover Mapping with Sentinel-2</strong><br>
-    Demonstrate how to perform a basic land cover mapping using random forest and the Sentinel-2 data in EOPF Zarr format
+    Demonstrate how to perform a basic land cover mapping using random forest and the Sentinel-2 data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/Sentinel-2/Random_Forest_Land_Cover" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel 1 Surface Soil Moisture (SSM)</strong><br>
-    Learn how to compute surface soil moisture from Sentinel-1 data
+    Learn how to compute surface soil moisture from Sentinel-1 data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_Soil_moisture" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-1 GRD Zarr Product Exploration</strong><br>
-    Explore how to open, inspect the metadata and visualise Sentinel-1 GRD Zarr format
+    Explore how to open, inspect the metadata and visualise Sentinel-1 GRD Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L1_GRD_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-1 SLC Zarr Product Exploration</strong><br>
-    Explore how to open, inspect the metadata and process Sentinel-1 Single Look Complex (SLC) Zarr format
+    Explore how to open, inspect the metadata and process Sentinel-1 Single Look Complex (SLC) Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L1_SLC_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-2 Crop-Type Classification</strong><br>
-    
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/sentinel-2_crop_type_classification_rule-based" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-2 L1C MSI Zarr Product Exploration</strong><br>
-    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
+    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_MSI_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 stac land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land stac sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>STAC-Based Exploration and Visualization of Sentinel-2 and Sentinel-1 Data</strong><br>
-    Learn how to access Sentinel-2 and Sentinel-1 images via the EOPF STAC Catalog using pystac-client
+    Learn how to access Sentinel-2 and Sentinel-1 images via the EOPF STAC Catalog using pystac-client<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">stac</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">stac</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/STAC/STAC_EOPF_ZARR_SENTINEL" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 land xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>xarray EOPF backend - Sentinel-1 Native Mode</strong><br>
-    Learn how to access Sentinel-1 products in native mode
+    Learn how to access Sentinel-1 products in native mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">land</span><span class="tag">xarray-eopf</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_1_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -280,7 +279,7 @@ Notebooks organized by Earth observation application domains
   </div>
   <div style="flex: 1;">
     <strong>xarray EOPF backend - Sentinel-2 Analysis Mode</strong><br>
-    Learn how to access Sentinel-2 products in analysis mode
+    Learn how to access Sentinel-2 products in analysis mode<br>
     <div style="margin: 6px 0;">
       <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
@@ -293,48 +292,48 @@ Notebooks organized by Earth observation application domains
   </div>
   <div style="flex: 1;">
     <strong>xarray EOPF backend - Sentinel-2 Native mode</strong><br>
-    Learn how to access Sentinel-2 products in native mode
+    Learn how to access Sentinel-2 products in native mode<br>
     <div style="margin: 6px 0;">
       <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_2_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-3 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>xarray EOPF backend - Sentinel-3 Analysis Mode</strong><br>
-    Learn how to access Sentinel-3 products in analysis mode
+    Learn how to access Sentinel-3 products in analysis mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span>
+      <span class="tag">land</span><span class="tag">sentinel-3</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_3_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-3 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>xarray EOPF backend - Sentinel-3 Native Mode</strong><br>
-    Learn how to access Sentinel-3 products in native mode
+    Learn how to access Sentinel-3 products in native mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span>
+      <span class="tag">land</span><span class="tag">sentinel-3</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_3_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="gdal land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land gdal sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Zarr vs SAFE Metadata</strong><br>
-    Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)
+    Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)<br>
     <div style="margin: 6px 0;">
-      <span class="tag">gdal</span><span class="tag">land</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">gdal</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/SAFE_Zarr_Metadata_Comparison_S2_L2A" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -344,93 +343,92 @@ Notebooks organized by Earth observation application domains
 ## Climate Monitoring
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="climate-change xarray sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Heatwave in Netherlands</strong><br>
-    Learn how to read, process and use Sentinel-3 Land Surface Temperature
+    Learn how to read, process and use Sentinel-3 Land Surface Temperature<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-3/Sentinel-3_Heatwave_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change sentinel-2 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>NDSI based snow mapping with Sentinel-2</strong><br>
-    Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format
+    Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
+      <span class="tag">climate-change</span><span class="tag">sentinel-2</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_NDSI_Snow_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change gdal sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 climate-change gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Open Sentinel-3-OLCI-Level-1-EFR Data with GDAL and eopfzarr</strong><br>
-    
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">gdal</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3-OLCI-Level-1-EFR" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change xarray sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Regridding Sentinel-3 SLSTR Data</strong><br>
-    Learn how to regridding Sentinel-3 SLSTR data
+    Learn how to regridding Sentinel-3 SLSTR data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-3/Regridding_Sentinel_3_SLSTR_LST" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change gdal sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 climate-change gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/ESA_EOPF_logo_2025_COLOR_ESA_blue_reduced.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-3 Multi-Product Demo with GDAL</strong><br>
-    Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver
+    Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">gdal</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3_Multi-Product-Demo" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray climate-change sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Surface Water Level Monitoring with Sentinel-2</strong><br>
-    Timeseries of water covered area at Santa Giustina lake, Italy
+    Timeseries of water covered area at Santa Giustina lake, Italy<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">climate-change</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/water_level_timeseries" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change stac sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="stac climate-change sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Wildfire Burn Severity Assessment Using Sentinel-2 L2A Data and dNBR</strong><br>
-    A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Gerês wildfire event (Portugal, July 2025).
+    A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Gerês wildfire event (Portugal, July 2025).<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">stac</span><span class="tag">sentinel-2</span>
+      <span class="tag">stac</span><span class="tag">climate-change</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_wildfire_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -446,35 +444,35 @@ Notebooks organized by Earth observation application domains
   </div>
   <div style="flex: 1;">
     <strong>OSI - Oil Spill Index</strong><br>
-    Learn how to use the Oil Spill Index (OSI) to detect oil spills using Sentine-2 data.
+    Learn how to use the Oil Spill Index (OSI) to detect oil spills using Sentine-2 data.<br>
     <div style="margin: 6px 0;">
       <span class="tag">sentinel 2</span><span class="tag">stac</span><span class="tag">marine</span>
     </div>
     <a href="/notebooks/Sentinel-2/oil_spill_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="marine sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-1 L2 OCN Zarr Product Exploration</strong><br>
-    Explore how to open, visualise and use Sentinel-1 OCN products in EOPF Zarr format
+    Explore how to open, visualise and use Sentinel-1 OCN products in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">marine</span>
+      <span class="tag">marine</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L2_OCN_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray marine sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="marine xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Transforming workflow for oceanography study using Sentinel‑2 data, from SAFE to Zarr</strong><br>
-    Computing wave spectra with 2D FFT & coherence in the EOPF framework
+    Computing wave spectra with 2D FFT & coherence in the EOPF framework<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">marine</span><span class="tag">sentinel-2</span>
+      <span class="tag">marine</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/oceanographic_wave_spectral_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -490,7 +488,7 @@ Notebooks organized by Earth observation application domains
   </div>
   <div style="flex: 1;">
     <strong>Deforestation Monitoring using Sentinel 2 and xarray</strong><br>
-    Streamlining Cloud-Based Processing with EOPF and Xarray
+    Streamlining Cloud-Based Processing with EOPF and Xarray<br>
     <div style="margin: 6px 0;">
       <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
@@ -503,7 +501,7 @@ Notebooks organized by Earth observation application domains
   </div>
   <div style="flex: 1;">
     <strong>NDVI-based approach to study Landslide areas</strong><br>
-    Streamlining Cloud-Based Processing with EOPF and Xarray
+    Streamlining Cloud-Based Processing with EOPF and Xarray<br>
     <div style="margin: 6px 0;">
       <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
@@ -511,3 +509,4 @@ Notebooks organized by Earth observation application domains
   </div>
 </div>
 </div>
+

--- a/notebooks/gallery-topics.md
+++ b/notebooks/gallery-topics.md
@@ -511,4 +511,3 @@ Notebooks organized by Earth observation application domains
   </div>
 </div>
 </div>
-

--- a/notebooks/gallery-topics.md
+++ b/notebooks/gallery-topics.md
@@ -14,7 +14,7 @@ Notebooks organized by Earth observation application domains
 ## Land Applications
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -22,12 +22,12 @@ Notebooks organized by Earth observation application domains
     <strong>Accessing Zarr Data</strong><br>
     Explore how to access Data in Zarr format.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/STAC/Data_Access_Tutorial" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 stac land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="stac land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -35,12 +35,12 @@ Notebooks organized by Earth observation application domains
     <strong>Analysing snow cover in the Alps using Sentinel-2</strong><br>
     Learn how to use the EOPF Zarr data to analyse snow cover dynamics in the Alps with Sentinel-2 imagery.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">stac</span><span class="tag">land</span>
+      <span class="tag">stac</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_snow_cover_fraction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -48,12 +48,12 @@ Notebooks organized by Earth observation application domains
     <strong>Building Sentinel-2 Data Cubes with xcube EOPF Data Store</strong><br>
     Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/sentinel_2" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xcube sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xcube sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -61,12 +61,12 @@ Notebooks organized by Earth observation application domains
     <strong>Building Sentinel-3 Data Cubes with xcube EOPF Data Store</strong><br>
     Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.
     <div style="margin: 6px 0;">
-      <span class="tag">xcube</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/sentinel_3" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 openeo land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land stac openeo sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -74,12 +74,12 @@ Notebooks organized by Earth observation application domains
     <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
     Learn how to use the EOPF Zarr data through STAC and openEO
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">openeo</span><span class="tag">land</span><span class="tag">stac</span>
+      <span class="tag">land</span><span class="tag">stac</span><span class="tag">openeo</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/eopf_openeo_stac_remote" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 openeo land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land stac openeo sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -87,12 +87,12 @@ Notebooks organized by Earth observation application domains
     <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
     Learn how to use the EOPF Zarr data through STAC and openEO
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">openeo</span><span class="tag">land</span><span class="tag">stac</span>
+      <span class="tag">land</span><span class="tag">stac</span><span class="tag">openeo</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/eopf_openeo_stac" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 land gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="gdal land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -100,12 +100,12 @@ Notebooks organized by Earth observation application domains
     <strong>Explore EOPF Zarr Sentinel-2 files using GDAL</strong><br>
     Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">land</span><span class="tag">gdal</span>
+      <span class="tag">gdal</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/GDAL_explore_Zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -113,12 +113,12 @@ Notebooks organized by Earth observation application domains
     <strong>Intoduction to the xarray EOPF backend</strong><br>
     Access and explore analysis-ready and native EOPF Zarr data using xarray
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -126,12 +126,12 @@ Notebooks organized by Earth observation application domains
     <strong>Introduction to the xcube EOPF Data Store</strong><br>
     Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xcube_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -139,12 +139,12 @@ Notebooks organized by Earth observation application domains
     <strong>NDVI Time-Series Analysis of Potato Fields</strong><br>
     A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Potato_Field_Crop_Type" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -152,7 +152,7 @@ Notebooks organized by Earth observation application domains
     <strong>Parcel delineation using Sentinel-2</strong><br>
     Delineating agricultural parcels based on a neural network, using Sentinel-2 input data
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/parcel_delineation_sentinel" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -170,7 +170,7 @@ Notebooks organized by Earth observation application domains
     <a href="/notebooks/Sentinel-1/radar_vegetation_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -178,7 +178,7 @@ Notebooks organized by Earth observation application domains
     <strong>Random Forest Based Land-Cover Mapping with Sentinel-2</strong><br>
     Demonstrate how to perform a basic land cover mapping using random forest and the Sentinel-2 data in EOPF Zarr format
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Random_Forest_Land_Cover" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -222,7 +222,7 @@ Notebooks organized by Earth observation application domains
     <a href="/notebooks/Sentinel-1/Sentinel-1_L1_SLC_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -230,12 +230,12 @@ Notebooks organized by Earth observation application domains
     <strong>Sentinel-2 Crop-Type Classification</strong><br>
     
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/sentinel-2_crop_type_classification_rule-based" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -243,12 +243,12 @@ Notebooks organized by Earth observation application domains
     <strong>Sentinel-2 L1C MSI Zarr Product Exploration</strong><br>
     Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_MSI_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-1 stac land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -256,12 +256,12 @@ Notebooks organized by Earth observation application domains
     <strong>STAC-Based Exploration and Visualization of Sentinel-2 and Sentinel-1 Data</strong><br>
     Learn how to access Sentinel-2 and Sentinel-1 images via the EOPF STAC Catalog using pystac-client
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">land</span><span class="tag">stac</span>
+      <span class="tag">sentinel-1</span><span class="tag">stac</span><span class="tag">land</span>
     </div>
     <a href="/notebooks/STAC/STAC_EOPF_ZARR_SENTINEL" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-1 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-1 land xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -269,12 +269,12 @@ Notebooks organized by Earth observation application domains
     <strong>xarray EOPF backend - Sentinel-1 Native Mode</strong><br>
     Learn how to access Sentinel-1 products in native mode
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-1</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+      <span class="tag">sentinel-1</span><span class="tag">land</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_1_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -282,12 +282,12 @@ Notebooks organized by Earth observation application domains
     <strong>xarray EOPF backend - Sentinel-2 Analysis Mode</strong><br>
     Learn how to access Sentinel-2 products in analysis mode
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_2_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -295,12 +295,12 @@ Notebooks organized by Earth observation application domains
     <strong>xarray EOPF backend - Sentinel-2 Native mode</strong><br>
     Learn how to access Sentinel-2 products in native mode
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_2_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray-eopf sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -308,12 +308,12 @@ Notebooks organized by Earth observation application domains
     <strong>xarray EOPF backend - Sentinel-3 Analysis Mode</strong><br>
     Learn how to access Sentinel-3 products in analysis mode
     <div style="margin: 6px 0;">
-      <span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_3_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray-eopf sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land xarray-eopf sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -321,12 +321,12 @@ Notebooks organized by Earth observation application domains
     <strong>xarray EOPF backend - Sentinel-3 Native Mode</strong><br>
     Learn how to access Sentinel-3 products in native mode
     <div style="margin: 6px 0;">
-      <span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_3_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 land gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="gdal land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -334,7 +334,7 @@ Notebooks organized by Earth observation application domains
     <strong>Zarr vs SAFE Metadata</strong><br>
     Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">land</span><span class="tag">gdal</span>
+      <span class="tag">gdal</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/SAFE_Zarr_Metadata_Comparison_S2_L2A" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -344,7 +344,7 @@ Notebooks organized by Earth observation application domains
 ## Climate Monitoring
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="climate-change sentinel-3 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change xarray sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -352,12 +352,12 @@ Notebooks organized by Earth observation application domains
     <strong>Heatwave in Netherlands</strong><br>
     Learn how to read, process and use Sentinel-3 Land Surface Temperature
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">xarray</span>
+      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/Sentinel-3/Sentinel-3_Heatwave_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 climate-change xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change xcube sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -365,12 +365,12 @@ Notebooks organized by Earth observation application domains
     <strong>NDSI based snow mapping with Sentinel-2</strong><br>
     Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">xcube</span>
+      <span class="tag">climate-change</span><span class="tag">xcube</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_NDSI_Snow_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="gdal climate-change sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change gdal sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -378,12 +378,12 @@ Notebooks organized by Earth observation application domains
     <strong>Open Sentinel-3-OLCI-Level-1-EFR Data with GDAL and eopfzarr</strong><br>
     
     <div style="margin: 6px 0;">
-      <span class="tag">gdal</span><span class="tag">climate-change</span><span class="tag">sentinel-3</span>
+      <span class="tag">climate-change</span><span class="tag">gdal</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3-OLCI-Level-1-EFR" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change sentinel-3 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change xarray sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -391,12 +391,12 @@ Notebooks organized by Earth observation application domains
     <strong>Regridding Sentinel-3 SLSTR Data</strong><br>
     Learn how to regridding Sentinel-3 SLSTR data
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">xarray</span>
+      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/Sentinel-3/Regridding_Sentinel_3_SLSTR_LST" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="gdal climate-change sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change gdal sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/ESA_EOPF_logo_2025_COLOR_ESA_blue_reduced.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -404,12 +404,12 @@ Notebooks organized by Earth observation application domains
     <strong>Sentinel-3 Multi-Product Demo with GDAL</strong><br>
     Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver
     <div style="margin: 6px 0;">
-      <span class="tag">gdal</span><span class="tag">climate-change</span><span class="tag">sentinel-3</span>
+      <span class="tag">climate-change</span><span class="tag">gdal</span><span class="tag">sentinel-3</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3_Multi-Product-Demo" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -417,12 +417,12 @@ Notebooks organized by Earth observation application domains
     <strong>Surface Water Level Monitoring with Sentinel-2</strong><br>
     Timeseries of water covered area at Santa Giustina lake, Italy
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">xarray</span>
+      <span class="tag">climate-change</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/water_level_timeseries" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 climate-change stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change stac sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -430,7 +430,7 @@ Notebooks organized by Earth observation application domains
     <strong>Wildfire Burn Severity Assessment Using Sentinel-2 L2A Data and dNBR</strong><br>
     A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Gerês wildfire event (Portugal, July 2025).
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">stac</span>
+      <span class="tag">climate-change</span><span class="tag">stac</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_wildfire_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -466,7 +466,7 @@ Notebooks organized by Earth observation application domains
     <a href="/notebooks/Sentinel-1/Sentinel-1_L2_OCN_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray marine sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -474,7 +474,7 @@ Notebooks organized by Earth observation application domains
     <strong>Transforming workflow for oceanography study using Sentinel‑2 data, from SAFE to Zarr</strong><br>
     Computing wave spectra with 2D FFT & coherence in the EOPF framework
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">marine</span>
+      <span class="tag">xarray</span><span class="tag">marine</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/oceanographic_wave_spectral_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -484,7 +484,7 @@ Notebooks organized by Earth observation application domains
 ## Emergency and Security Applications
 
 <div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="sentinel-2 xarray security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="security xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -492,12 +492,12 @@ Notebooks organized by Earth observation application domains
     <strong>Deforestation Monitoring using Sentinel 2 and xarray</strong><br>
     Streamlining Cloud-Based Processing with EOPF and Xarray
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">security</span>
+      <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/deforestation_monitoring_zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-2 xarray security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="security xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -505,9 +505,10 @@ Notebooks organized by Earth observation application domains
     <strong>NDVI-based approach to study Landslide areas</strong><br>
     Streamlining Cloud-Based Processing with EOPF and Xarray
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">security</span>
+      <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/NDVI_based_landslide_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
 </div>
+

--- a/notebooks/gallery-topics.md
+++ b/notebooks/gallery-topics.md
@@ -509,4 +509,3 @@ Notebooks organized by Earth observation application domains
   </div>
 </div>
 </div>
-

--- a/notebooks/gallery-topics.md
+++ b/notebooks/gallery-topics.md
@@ -13,28 +13,502 @@ Notebooks organized by Earth observation application domains
 
 ## Land Applications
 
-```{gallery-grid}
-:category: land
-:columns: 1 1 2 3
-```
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Accessing Zarr Data</strong><br>
+    Explore how to access Data in Zarr format.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/STAC/Data_Access_Tutorial" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 stac land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Analysing snow cover in the Alps using Sentinel-2</strong><br>
+    Learn how to use the EOPF Zarr data to analyse snow cover dynamics in the Alps with Sentinel-2 imagery.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">stac</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Sentinel-2_snow_cover_fraction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Building Sentinel-2 Data Cubes with xcube EOPF Data Store</strong><br>
+    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-2 Zarr samples.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xcube_eopf_plugin/sentinel_2" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="xcube sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Building Sentinel-3 Data Cubes with xcube EOPF Data Store</strong><br>
+    Learn how to build analysis-ready data cubes from multiple EOPF Sentinel-3 Zarr samples.
+    <div style="margin: 6px 0;">
+      <span class="tag">xcube</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xcube_eopf_plugin/sentinel_3" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 openeo land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
+    Learn how to use the EOPF Zarr data through STAC and openEO
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">openeo</span><span class="tag">land</span><span class="tag">stac</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/eopf_openeo_stac_remote" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 openeo land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>EOPF Zarr Data Access with openEO and STAC</strong><br>
+    Learn how to use the EOPF Zarr data through STAC and openEO
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">openeo</span><span class="tag">land</span><span class="tag">stac</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/eopf_openeo_stac" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 land gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Explore EOPF Zarr Sentinel-2 files using GDAL</strong><br>
+    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">land</span><span class="tag">gdal</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/GDAL_explore_Zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Intoduction to the xarray EOPF backend</strong><br>
+    Access and explore analysis-ready and native EOPF Zarr data using xarray
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Introduction to the xcube EOPF Data Store</strong><br>
+    Learn how to build analysis-ready data cubes from multiple EOPF Zarr samples.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xcube_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>NDVI Time-Series Analysis of Potato Fields</strong><br>
+    A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Potato_Field_Crop_Type" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Parcel delineation using Sentinel-2</strong><br>
+    Delineating agricultural parcels based on a neural network, using Sentinel-2 input data
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/parcel_delineation_sentinel" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Radar Vegetation Index</strong><br>
+    Monitor vegetation crop growth using Sentinel-1 GRD data
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/radar_vegetation_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xcube land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Random Forest Based Land-Cover Mapping with Sentinel-2</strong><br>
+    Demonstrate how to perform a basic land cover mapping using random forest and the Sentinel-2 data in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xcube</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Random_Forest_Land_Cover" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel 1 Surface Soil Moisture (SSM)</strong><br>
+    Learn how to compute surface soil moisture from Sentinel-1 data
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/Sentinel-1_Soil_moisture" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-1 GRD Zarr Product Exploration</strong><br>
+    Explore how to open, inspect the metadata and visualise Sentinel-1 GRD Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/Sentinel-1_L1_GRD_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-1 SLC Zarr Product Exploration</strong><br>
+    Explore how to open, inspect the metadata and process Sentinel-1 Single Look Complex (SLC) Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/Sentinel-1_L1_SLC_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-2 Crop-Type Classification</strong><br>
+    
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/sentinel-2_crop_type_classification_rule-based" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-2 L1C MSI Zarr Product Exploration</strong><br>
+    Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_MSI_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 land stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>STAC-Based Exploration and Visualization of Sentinel-2 and Sentinel-1 Data</strong><br>
+    Learn how to access Sentinel-2 and Sentinel-1 images via the EOPF STAC Catalog using pystac-client
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">land</span><span class="tag">stac</span>
+    </div>
+    <a href="/notebooks/STAC/STAC_EOPF_ZARR_SENTINEL" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>xarray EOPF backend - Sentinel-1 Native Mode</strong><br>
+    Learn how to access Sentinel-1 products in native mode
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/sentinel_1_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>xarray EOPF backend - Sentinel-2 Analysis Mode</strong><br>
+    Learn how to access Sentinel-2 products in analysis mode
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/sentinel_2_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray-eopf land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>xarray EOPF backend - Sentinel-2 Native mode</strong><br>
+    Learn how to access Sentinel-2 products in native mode
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/sentinel_2_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="xarray-eopf sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>xarray EOPF backend - Sentinel-3 Analysis Mode</strong><br>
+    Learn how to access Sentinel-3 products in analysis mode
+    <div style="margin: 6px 0;">
+      <span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/sentinel_3_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="xarray-eopf sentinel-3 land" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>xarray EOPF backend - Sentinel-3 Native Mode</strong><br>
+    Learn how to access Sentinel-3 products in native mode
+    <div style="margin: 6px 0;">
+      <span class="tag">xarray-eopf</span><span class="tag">sentinel-3</span><span class="tag">land</span>
+    </div>
+    <a href="/notebooks/xarray_eopf_plugin/sentinel_3_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 land gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Zarr vs SAFE Metadata</strong><br>
+    Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">land</span><span class="tag">gdal</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/SAFE_Zarr_Metadata_Comparison_S2_L2A" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+</div>
 
 ## Climate Monitoring
 
-```{gallery-grid}
-:category: climate-change
-:columns: 1 1 2 3
-```
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div class="notebook-card" data-tags="climate-change sentinel-3 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Heatwave in Netherlands</strong><br>
+    Learn how to read, process and use Sentinel-3 Land Surface Temperature
+    <div style="margin: 6px 0;">
+      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">xarray</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/Sentinel-3_Heatwave_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 climate-change xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>NDSI based snow mapping with Sentinel-2</strong><br>
+    Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">xcube</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Sentinel-2_NDSI_Snow_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="gdal climate-change sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Open Sentinel-3-OLCI-Level-1-EFR Data with GDAL and eopfzarr</strong><br>
+    
+    <div style="margin: 6px 0;">
+      <span class="tag">gdal</span><span class="tag">climate-change</span><span class="tag">sentinel-3</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3-OLCI-Level-1-EFR" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="climate-change sentinel-3 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Regridding Sentinel-3 SLSTR Data</strong><br>
+    Learn how to regridding Sentinel-3 SLSTR data
+    <div style="margin: 6px 0;">
+      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">xarray</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/Regridding_Sentinel_3_SLSTR_LST" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="gdal climate-change sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/ESA_EOPF_logo_2025_COLOR_ESA_blue_reduced.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-3 Multi-Product Demo with GDAL</strong><br>
+    Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver
+    <div style="margin: 6px 0;">
+      <span class="tag">gdal</span><span class="tag">climate-change</span><span class="tag">sentinel-3</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3_Multi-Product-Demo" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Surface Water Level Monitoring with Sentinel-2</strong><br>
+    Timeseries of water covered area at Santa Giustina lake, Italy
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">xarray</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/water_level_timeseries" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 climate-change stac" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Wildfire Burn Severity Assessment Using Sentinel-2 L2A Data and dNBR</strong><br>
+    A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Gerês wildfire event (Portugal, July 2025).
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">stac</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Sentinel-2_wildfire_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+</div>
 
 ## Marine Applications
 
-```{gallery-grid}
-:category: marine
-:columns: 1 1 2 3
-```
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div class="notebook-card" data-tags="sentinel 2 stac marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>OSI - Oil Spill Index</strong><br>
+    Learn how to use the Oil Spill Index (OSI) to detect oil spills using Sentine-2 data.
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel 2</span><span class="tag">stac</span><span class="tag">marine</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/oil_spill_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-1 xarray marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-1 L2 OCN Zarr Product Exploration</strong><br>
+    Explore how to open, visualise and use Sentinel-1 OCN products in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-1</span><span class="tag">xarray</span><span class="tag">marine</span>
+    </div>
+    <a href="/notebooks/Sentinel-1/Sentinel-1_L2_OCN_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Transforming workflow for oceanography study using Sentinel‑2 data, from SAFE to Zarr</strong><br>
+    Computing wave spectra with 2D FFT & coherence in the EOPF framework
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">marine</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/oceanographic_wave_spectral_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+</div>
 
 ## Emergency and Security Applications
 
-```{gallery-grid}
-:category: security
-:columns: 1 1 2 3
-```
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div class="notebook-card" data-tags="sentinel-2 xarray security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Deforestation Monitoring using Sentinel 2 and xarray</strong><br>
+    Streamlining Cloud-Based Processing with EOPF and Xarray
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">security</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/deforestation_monitoring_zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="sentinel-2 xarray security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>NDVI-based approach to study Landslide areas</strong><br>
+    Streamlining Cloud-Based Processing with EOPF and Xarray
+    <div style="margin: 6px 0;">
+      <span class="tag">sentinel-2</span><span class="tag">xarray</span><span class="tag">security</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/NDVI_based_landslide_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+</div>
+

--- a/notebooks/gallery-topics.md
+++ b/notebooks/gallery-topics.md
@@ -13,8 +13,8 @@ Notebooks organized by Earth observation application domains
 
 ## Land Applications
 
-<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px; margin-bottom: 40px;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -22,7 +22,7 @@ Notebooks organized by Earth observation application domains
     <strong>Accessing Zarr Data</strong><br>
     Explore how to access Data in Zarr format.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/STAC/Data_Access_Tutorial" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -92,7 +92,7 @@ Notebooks organized by Earth observation application domains
     <a href="/notebooks/Sentinel-2/eopf_openeo_stac" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land gdal sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -100,12 +100,12 @@ Notebooks organized by Earth observation application domains
     <strong>Explore EOPF Zarr Sentinel-2 files using GDAL</strong><br>
     Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">gdal</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-2/GDAL_explore_Zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -113,7 +113,7 @@ Notebooks organized by Earth observation application domains
     <strong>Intoduction to the xarray EOPF backend</strong><br>
     Access and explore analysis-ready and native EOPF Zarr data using xarray<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -131,7 +131,7 @@ Notebooks organized by Earth observation application domains
     <a href="/notebooks/xcube_eopf_plugin/introduction" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -139,12 +139,12 @@ Notebooks organized by Earth observation application domains
     <strong>NDVI Time-Series Analysis of Potato Fields</strong><br>
     A step-by-step guide to extracting and analyzing temporal NDVI profiles from potato fields for crop-type studies.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Potato_Field_Crop_Type" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -152,12 +152,12 @@ Notebooks organized by Earth observation application domains
     <strong>Parcel delineation using Sentinel-2</strong><br>
     Delineating agricultural parcels based on a neural network, using Sentinel-2 input data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/parcel_delineation_sentinel" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -165,7 +165,7 @@ Notebooks organized by Earth observation application domains
     <strong>Radar Vegetation Index</strong><br>
     Monitor vegetation crop growth using Sentinel-1 GRD data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/Sentinel-1/radar_vegetation_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -183,7 +183,7 @@ Notebooks organized by Earth observation application domains
     <a href="/notebooks/Sentinel-2/Random_Forest_Land_Cover" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -191,12 +191,12 @@ Notebooks organized by Earth observation application domains
     <strong>Sentinel 1 Surface Soil Moisture (SSM)</strong><br>
     Learn how to compute surface soil moisture from Sentinel-1 data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_Soil_moisture" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -204,12 +204,12 @@ Notebooks organized by Earth observation application domains
     <strong>Sentinel-1 GRD Zarr Product Exploration</strong><br>
     Explore how to open, inspect the metadata and visualise Sentinel-1 GRD Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L1_GRD_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -217,24 +217,24 @@ Notebooks organized by Earth observation application domains
     <strong>Sentinel-1 SLC Zarr Product Exploration</strong><br>
     Explore how to open, inspect the metadata and process Sentinel-1 Single Look Complex (SLC) Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-1</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L1_SLC_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-2 Crop-Type Classification</strong><br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/sentinel-2_crop_type_classification_rule-based" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray land sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -242,7 +242,7 @@ Notebooks organized by Earth observation application domains
     <strong>Sentinel-2 L1C MSI Zarr Product Exploration</strong><br>
     Explore how to open, visualise and plot Sentinel-2 L1C MSI EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">land</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_MSI_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -260,7 +260,7 @@ Notebooks organized by Earth observation application domains
     <a href="/notebooks/STAC/STAC_EOPF_ZARR_SENTINEL" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-1" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-1 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -268,12 +268,12 @@ Notebooks organized by Earth observation application domains
     <strong>xarray EOPF backend - Sentinel-1 Native Mode</strong><br>
     Learn how to access Sentinel-1 products in native mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-1</span>
+      <span class="tag">land</span><span class="tag">sentinel-1</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_1_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -281,12 +281,12 @@ Notebooks organized by Earth observation application domains
     <strong>xarray EOPF backend - Sentinel-2 Analysis Mode</strong><br>
     Learn how to access Sentinel-2 products in analysis mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_2_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land xarray-eopf sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 xarray-eopf" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -294,7 +294,7 @@ Notebooks organized by Earth observation application domains
     <strong>xarray EOPF backend - Sentinel-2 Native mode</strong><br>
     Learn how to access Sentinel-2 products in native mode<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">xarray-eopf</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">xarray-eopf</span>
     </div>
     <a href="/notebooks/xarray_eopf_plugin/sentinel_2_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -325,7 +325,7 @@ Notebooks organized by Earth observation application domains
     <a href="/notebooks/xarray_eopf_plugin/sentinel_3_native" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="land gdal sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="land sentinel-2 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -333,7 +333,7 @@ Notebooks organized by Earth observation application domains
     <strong>Zarr vs SAFE Metadata</strong><br>
     Learn how to extract Metadata from EOPF Zarr, in comparison with SAFE (Standard Archive Format for Europe) using GDAL & Xarray (Sentinel-2 L2A)<br>
     <div style="margin: 6px 0;">
-      <span class="tag">land</span><span class="tag">gdal</span><span class="tag">sentinel-2</span>
+      <span class="tag">land</span><span class="tag">sentinel-2</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-2/SAFE_Zarr_Metadata_Comparison_S2_L2A" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -342,8 +342,8 @@ Notebooks organized by Earth observation application domains
 
 ## Climate Monitoring
 
-<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="sentinel-3 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px; margin-bottom: 40px;">
+<div class="notebook-card" data-tags="xarray sentinel-3 climate-change" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -351,12 +351,12 @@ Notebooks organized by Earth observation application domains
     <strong>Heatwave in Netherlands</strong><br>
     Learn how to read, process and use Sentinel-3 Land Surface Temperature<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-3</span><span class="tag">climate-change</span>
     </div>
     <a href="/notebooks/Sentinel-3/Sentinel-3_Heatwave_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="climate-change sentinel-2 xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-2 climate-change xcube" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -364,24 +364,24 @@ Notebooks organized by Earth observation application domains
     <strong>NDSI based snow mapping with Sentinel-2</strong><br>
     Demonstrate how to map snow coverage using the Sentinel-2 data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">climate-change</span><span class="tag">sentinel-2</span><span class="tag">xcube</span>
+      <span class="tag">sentinel-2</span><span class="tag">climate-change</span><span class="tag">xcube</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_NDSI_Snow_Mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-3 climate-change gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change sentinel-3 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Open Sentinel-3-OLCI-Level-1-EFR Data with GDAL and eopfzarr</strong><br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">gdal</span>
+      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3-OLCI-Level-1-EFR" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-3 climate-change xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-3 climate-change" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -389,12 +389,12 @@ Notebooks organized by Earth observation application domains
     <strong>Regridding Sentinel-3 SLSTR Data</strong><br>
     Learn how to regridding Sentinel-3 SLSTR data<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-3</span><span class="tag">climate-change</span>
     </div>
     <a href="/notebooks/Sentinel-3/Regridding_Sentinel_3_SLSTR_LST" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="sentinel-3 climate-change gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="climate-change sentinel-3 gdal" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/ESA_EOPF_logo_2025_COLOR_ESA_blue_reduced.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -402,12 +402,12 @@ Notebooks organized by Earth observation application domains
     <strong>Sentinel-3 Multi-Product Demo with GDAL</strong><br>
     Comprehensive demonstration of accessing multiple Sentinel-3 product types using GDAL EOPFZARR driver<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel-3</span><span class="tag">climate-change</span><span class="tag">gdal</span>
+      <span class="tag">climate-change</span><span class="tag">sentinel-3</span><span class="tag">gdal</span>
     </div>
     <a href="/notebooks/Sentinel-3/GDAL_Sentinel-3_Multi-Product-Demo" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="xarray climate-change sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-2 climate-change" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -415,12 +415,12 @@ Notebooks organized by Earth observation application domains
     <strong>Surface Water Level Monitoring with Sentinel-2</strong><br>
     Timeseries of water covered area at Santa Giustina lake, Italy<br>
     <div style="margin: 6px 0;">
-      <span class="tag">xarray</span><span class="tag">climate-change</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-2</span><span class="tag">climate-change</span>
     </div>
     <a href="/notebooks/Sentinel-2/water_level_timeseries" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="stac climate-change sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="stac sentinel-2 climate-change" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -428,7 +428,7 @@ Notebooks organized by Earth observation application domains
     <strong>Wildfire Burn Severity Assessment Using Sentinel-2 L2A Data and dNBR</strong><br>
     A hands-on tutorial using EOPF STAC Zarr datasets, Dask and  Xarray to map and quantify burnt areas for the Peneda-Gerês wildfire event (Portugal, July 2025).<br>
     <div style="margin: 6px 0;">
-      <span class="tag">stac</span><span class="tag">climate-change</span><span class="tag">sentinel-2</span>
+      <span class="tag">stac</span><span class="tag">sentinel-2</span><span class="tag">climate-change</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_wildfire_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -437,8 +437,8 @@ Notebooks organized by Earth observation application domains
 
 ## Marine Applications
 
-<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="sentinel 2 stac marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px; margin-bottom: 40px;">
+<div class="notebook-card" data-tags="stac marine sentinel 2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -446,12 +446,12 @@ Notebooks organized by Earth observation application domains
     <strong>OSI - Oil Spill Index</strong><br>
     Learn how to use the Oil Spill Index (OSI) to detect oil spills using Sentine-2 data.<br>
     <div style="margin: 6px 0;">
-      <span class="tag">sentinel 2</span><span class="tag">stac</span><span class="tag">marine</span>
+      <span class="tag">stac</span><span class="tag">marine</span><span class="tag">sentinel 2</span>
     </div>
     <a href="/notebooks/Sentinel-2/oil_spill_index" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="marine sentinel-1 xarray" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-1 marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -459,12 +459,12 @@ Notebooks organized by Earth observation application domains
     <strong>Sentinel-1 L2 OCN Zarr Product Exploration</strong><br>
     Explore how to open, visualise and use Sentinel-1 OCN products in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">marine</span><span class="tag">sentinel-1</span><span class="tag">xarray</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-1</span><span class="tag">marine</span>
     </div>
     <a href="/notebooks/Sentinel-1/Sentinel-1_L2_OCN_Zarr_product_exploration" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="marine xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-2 marine" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -472,7 +472,7 @@ Notebooks organized by Earth observation application domains
     <strong>Transforming workflow for oceanography study using Sentinel‑2 data, from SAFE to Zarr</strong><br>
     Computing wave spectra with 2D FFT & coherence in the EOPF framework<br>
     <div style="margin: 6px 0;">
-      <span class="tag">marine</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-2</span><span class="tag">marine</span>
     </div>
     <a href="/notebooks/Sentinel-2/oceanographic_wave_spectral_analysis" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
@@ -481,8 +481,8 @@ Notebooks organized by Earth observation application domains
 
 ## Emergency and Security Applications
 
-<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="security xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px; margin-bottom: 40px;">
+<div class="notebook-card" data-tags="xarray sentinel-2 security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -490,12 +490,12 @@ Notebooks organized by Earth observation application domains
     <strong>Deforestation Monitoring using Sentinel 2 and xarray</strong><br>
     Streamlining Cloud-Based Processing with EOPF and Xarray<br>
     <div style="margin: 6px 0;">
-      <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-2</span><span class="tag">security</span>
     </div>
     <a href="/notebooks/Sentinel-2/deforestation_monitoring_zarr" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="security xarray sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="xarray sentinel-2 security" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="https://raw.githubusercontent.com/EOPF-Sample-Service/eopf-sample-notebooks/refs/heads/main/notebooks/static/ESA_logo_2020_Deep.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -503,7 +503,7 @@ Notebooks organized by Earth observation application domains
     <strong>NDVI-based approach to study Landslide areas</strong><br>
     Streamlining Cloud-Based Processing with EOPF and Xarray<br>
     <div style="margin: 6px 0;">
-      <span class="tag">security</span><span class="tag">xarray</span><span class="tag">sentinel-2</span>
+      <span class="tag">xarray</span><span class="tag">sentinel-2</span><span class="tag">security</span>
     </div>
     <a href="/notebooks/Sentinel-2/NDVI_based_landslide_mapping" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>

--- a/notebooks/gallery-tutorials.md
+++ b/notebooks/gallery-tutorials.md
@@ -11,14 +11,89 @@ Notebooks demonstrating the main workflows for accessing and processing data
 
 ## Dask
 
-```{gallery-grid}
-:category: dask
-:columns: 1 1 2 3
-```
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div class="notebook-card" data-tags="dask" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Dask Intro</strong><br>
+    Explore how to connect to the dask gateway, spin up and scale a cluster and submit a simple workload.
+    <div style="margin: 6px 0;">
+      <span class="tag">dask</span>
+    </div>
+    <a href="/notebooks/Dask/Dask_Intro" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+</div>
 
 ## Basic Data Access
 
-```{gallery-grid}
-:category: basic
-:columns: 1 1 2 3
-```
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div class="notebook-card" data-tags="basic sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-2 L1C Data Access</strong><br>
+    Demonstrate how to access Sentinel-2 L1C data in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">basic</span><span class="tag">sentinel-2</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="basic sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-2 L2A Data Access</strong><br>
+    Demonstrate how to access Sentinel-2 L2A data in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">basic</span><span class="tag">sentinel-2</span>
+    </div>
+    <a href="/notebooks/Sentinel-2/Sentinel-2_L2A_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="basic sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-3 OLCI L1 EFR Data Access</strong><br>
+    Demonstrate how to access Sentinel-3 OLCI L1 EFR data in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">basic</span><span class="tag">sentinel-3</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/Sentinel-3_OLCI_L1_EFR_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="basic sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-3 OLCI L2 LFR Data Access</strong><br>
+    Demonstrate how to access Sentinel-3 OLCI L2 LFR data in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">basic</span><span class="tag">sentinel-3</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/Sentinel-3_OLCI_L2_LFR_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+<div class="notebook-card" data-tags="basic sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+  <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
+    <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
+  </div>
+  <div style="flex: 1;">
+    <strong>Sentinel-3 SLSTR L2 LST Data Access</strong><br>
+    Demonstrate how to access Sentinel-3 SLSTR L2 LST data in EOPF Zarr format
+    <div style="margin: 6px 0;">
+      <span class="tag">basic</span><span class="tag">sentinel-3</span>
+    </div>
+    <a href="/notebooks/Sentinel-3/Sentinel-3_SLSTR_L2_LST_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
+  </div>
+</div>
+</div>
+

--- a/notebooks/gallery-tutorials.md
+++ b/notebooks/gallery-tutorials.md
@@ -96,3 +96,4 @@ Notebooks demonstrating the main workflows for accessing and processing data
   </div>
 </div>
 </div>
+

--- a/notebooks/gallery-tutorials.md
+++ b/notebooks/gallery-tutorials.md
@@ -96,4 +96,3 @@ Notebooks demonstrating the main workflows for accessing and processing data
   </div>
 </div>
 </div>
-

--- a/notebooks/gallery-tutorials.md
+++ b/notebooks/gallery-tutorials.md
@@ -11,7 +11,7 @@ Notebooks demonstrating the main workflows for accessing and processing data
 
 ## Dask
 
-<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px; margin-bottom: 40px;">
 <div class="notebook-card" data-tags="dask" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
@@ -29,8 +29,8 @@ Notebooks demonstrating the main workflows for accessing and processing data
 
 ## Basic Data Access
 
-<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px;">
-<div class="notebook-card" data-tags="basic sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div style="display: flex; flex-direction: column; gap: 20px; max-width: 900px; margin-bottom: 40px;">
+<div class="notebook-card" data-tags="sentinel-2 basic" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -38,12 +38,12 @@ Notebooks demonstrating the main workflows for accessing and processing data
     <strong>Sentinel-2 L1C Data Access</strong><br>
     Demonstrate how to access Sentinel-2 L1C data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">basic</span><span class="tag">sentinel-2</span>
+      <span class="tag">sentinel-2</span><span class="tag">basic</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_L1C_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="basic sentinel-2" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-2 basic" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
@@ -51,7 +51,7 @@ Notebooks demonstrating the main workflows for accessing and processing data
     <strong>Sentinel-2 L2A Data Access</strong><br>
     Demonstrate how to access Sentinel-2 L2A data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">basic</span><span class="tag">sentinel-2</span>
+      <span class="tag">sentinel-2</span><span class="tag">basic</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_L2A_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>

--- a/notebooks/gallery-tutorials.md
+++ b/notebooks/gallery-tutorials.md
@@ -18,7 +18,7 @@ Notebooks demonstrating the main workflows for accessing and processing data
   </div>
   <div style="flex: 1;">
     <strong>Dask Intro</strong><br>
-    Explore how to connect to the dask gateway, spin up and scale a cluster and submit a simple workload.
+    Explore how to connect to the dask gateway, spin up and scale a cluster and submit a simple workload.<br>
     <div style="margin: 6px 0;">
       <span class="tag">dask</span>
     </div>
@@ -36,7 +36,7 @@ Notebooks demonstrating the main workflows for accessing and processing data
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-2 L1C Data Access</strong><br>
-    Demonstrate how to access Sentinel-2 L1C data in EOPF Zarr format
+    Demonstrate how to access Sentinel-2 L1C data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
       <span class="tag">basic</span><span class="tag">sentinel-2</span>
     </div>
@@ -49,50 +49,51 @@ Notebooks demonstrating the main workflows for accessing and processing data
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-2 L2A Data Access</strong><br>
-    Demonstrate how to access Sentinel-2 L2A data in EOPF Zarr format
+    Demonstrate how to access Sentinel-2 L2A data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
       <span class="tag">basic</span><span class="tag">sentinel-2</span>
     </div>
     <a href="/notebooks/Sentinel-2/Sentinel-2_L2A_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="basic sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 basic" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-3 OLCI L1 EFR Data Access</strong><br>
-    Demonstrate how to access Sentinel-3 OLCI L1 EFR data in EOPF Zarr format
+    Demonstrate how to access Sentinel-3 OLCI L1 EFR data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">basic</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">basic</span>
     </div>
     <a href="/notebooks/Sentinel-3/Sentinel-3_OLCI_L1_EFR_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="basic sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 basic" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-3 OLCI L2 LFR Data Access</strong><br>
-    Demonstrate how to access Sentinel-3 OLCI L2 LFR data in EOPF Zarr format
+    Demonstrate how to access Sentinel-3 OLCI L2 LFR data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">basic</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">basic</span>
     </div>
     <a href="/notebooks/Sentinel-3/Sentinel-3_OLCI_L2_LFR_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
-<div class="notebook-card" data-tags="basic sentinel-3" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
+<div class="notebook-card" data-tags="sentinel-3 basic" style="display: flex; align-items: flex-start; border: 1px solid #cddff1; border-radius: 6px; padding: 14px 20px; background-color: #f9fbfe; box-shadow: 1px 1px 4px #dfeaf5;">
   <div style="width: 100px; height: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; background-color: #fff; border: 1px solid #e0eaf5; border-radius: 6px; overflow: hidden; margin-right: 32px;">
     <img src="/notebooks/static/EOPF-on-bright-baseline.png" alt="Notebook Thumbnail" style="max-width: 100%; max-height: 100%; object-fit: contain;">
   </div>
   <div style="flex: 1;">
     <strong>Sentinel-3 SLSTR L2 LST Data Access</strong><br>
-    Demonstrate how to access Sentinel-3 SLSTR L2 LST data in EOPF Zarr format
+    Demonstrate how to access Sentinel-3 SLSTR L2 LST data in EOPF Zarr format<br>
     <div style="margin: 6px 0;">
-      <span class="tag">basic</span><span class="tag">sentinel-3</span>
+      <span class="tag">sentinel-3</span><span class="tag">basic</span>
     </div>
     <a href="/notebooks/Sentinel-3/Sentinel-3_SLSTR_L2_LST_data_access" style="text-decoration: none; color: #1d70b8; font-weight: bold;">View Notebook</a>
   </div>
 </div>
 </div>
+

--- a/notebooks/gallery.md
+++ b/notebooks/gallery.md
@@ -27,29 +27,31 @@ Once logged in, you will be able to run your notebook in JupyterLab!
 
 If you encounter any problem or have suggestions, please let us know on GitHub, opening a new issue [here](https://github.com/EOPF-Sample-Service/eopf-sample-notebooks/issues).
 
-
 ## Notebooks Gallery
 
 Click on the category to explore the corresponding notebooks!
 
 ### Sentinel Data
+
 <a class="link" href="gallery-sentinel#sentinel-1" ><p style="background-color:white;"><span class="gallery-tag tag-sentinel-1">🛰️ sentinel-1</span></p></a>
 <a class="link" href="gallery-sentinel#sentinel-2" ><p style="background-color:white;"><span class="gallery-tag tag-sentinel-2">🛰️ sentinel-2</span></p></a>
 <a class="link" href="gallery-sentinel#sentinel-3" ><p style="background-color:white;"><span class="gallery-tag tag-sentinel-3">🛰️ sentinel-3</span></p></a>
-                
+
 ### Application Topics
+
 <a class="link" href="gallery-topics#land-applications" ><p style="background-color:white;"><span class="gallery-tag tag-land">🌱 land</span></p></a>
 <a class="link" href="gallery-topics#climate-monitoring" ><p style="background-color:white;"><span class="gallery-tag tag-climate-change">🌡️ climate-change</span></p></a>
 <a class="link" href="gallery-topics#marine-applications" ><p style="background-color:white;"><span class="gallery-tag tag-marine">🌊 marine</span></p></a>
 <a class="link" href="gallery-topics#emergency-and-security-applications" ><p style="background-color:white;"><span class="gallery-tag tag-security">🔒 security</span></p></a>
 
 ### Tools & Libraries
+
 <a class="link" href="gallery-tools/#xarray" ><p style="background-color:white;"><span class="gallery-tag tag-xarray">📊 xarray</span></p></a>
 <a class="link" href="gallery-tools/#xarray-eopf-plugin" ><p style="background-color:white;"><span class="gallery-tag tag-xarray-eopf">🔌 xarray-eopf</span></p></a>
 <a class="link" href="gallery-tools/#xcube-eopf-plugin" ><p style="background-color:white;"><span class="gallery-tag tag-xcube">🏷️ xcube</span></p></a>
 <a class="link" href="gallery-tools/#gdal" ><p style="background-color:white;"><span class="gallery-tag tag-gdal">🗺️ gdal</span></p></a>
 
 ### Basic Tutorials
+
 <a class="link" href="gallery-tutorials/#dask" ><p style="background-color:white;"><span class="gallery-tag tag-dask">🧮 dask</span></p></a>
 <a class="link" href="gallery-tutorials/#basic-data-access" ><p style="background-color:white;"><span class="gallery-tag tag-basic">👶 basic</span></p></a>
-

--- a/notebooks/gallery.md
+++ b/notebooks/gallery.md
@@ -27,31 +27,29 @@ Once logged in, you will be able to run your notebook in JupyterLab!
 
 If you encounter any problem or have suggestions, please let us know on GitHub, opening a new issue [here](https://github.com/EOPF-Sample-Service/eopf-sample-notebooks/issues).
 
+
 ## Notebooks Gallery
 
 Click on the category to explore the corresponding notebooks!
 
 ### Sentinel Data
-
 <a class="link" href="gallery-sentinel#sentinel-1" ><p style="background-color:white;"><span class="gallery-tag tag-sentinel-1">🛰️ sentinel-1</span></p></a>
 <a class="link" href="gallery-sentinel#sentinel-2" ><p style="background-color:white;"><span class="gallery-tag tag-sentinel-2">🛰️ sentinel-2</span></p></a>
 <a class="link" href="gallery-sentinel#sentinel-3" ><p style="background-color:white;"><span class="gallery-tag tag-sentinel-3">🛰️ sentinel-3</span></p></a>
-
+                
 ### Application Topics
-
 <a class="link" href="gallery-topics#land-applications" ><p style="background-color:white;"><span class="gallery-tag tag-land">🌱 land</span></p></a>
 <a class="link" href="gallery-topics#climate-monitoring" ><p style="background-color:white;"><span class="gallery-tag tag-climate-change">🌡️ climate-change</span></p></a>
 <a class="link" href="gallery-topics#marine-applications" ><p style="background-color:white;"><span class="gallery-tag tag-marine">🌊 marine</span></p></a>
 <a class="link" href="gallery-topics#emergency-and-security-applications" ><p style="background-color:white;"><span class="gallery-tag tag-security">🔒 security</span></p></a>
 
 ### Tools & Libraries
-
 <a class="link" href="gallery-tools/#xarray" ><p style="background-color:white;"><span class="gallery-tag tag-xarray">📊 xarray</span></p></a>
 <a class="link" href="gallery-tools/#xarray-eopf-plugin" ><p style="background-color:white;"><span class="gallery-tag tag-xarray-eopf">🔌 xarray-eopf</span></p></a>
 <a class="link" href="gallery-tools/#xcube-eopf-plugin" ><p style="background-color:white;"><span class="gallery-tag tag-xcube">🏷️ xcube</span></p></a>
 <a class="link" href="gallery-tools/#gdal" ><p style="background-color:white;"><span class="gallery-tag tag-gdal">🗺️ gdal</span></p></a>
 
 ### Basic Tutorials
-
 <a class="link" href="gallery-tutorials/#dask" ><p style="background-color:white;"><span class="gallery-tag tag-dask">🧮 dask</span></p></a>
 <a class="link" href="gallery-tutorials/#basic-data-access" ><p style="background-color:white;"><span class="gallery-tag tag-basic">👶 basic</span></p></a>
+

--- a/notebooks/static/gallery.css
+++ b/notebooks/static/gallery.css
@@ -1,6 +1,41 @@
 /* EOPF Gallery CSS - Static Version */
 /* Edit this file directly to customize colors and styling */
 
+/* ========================================
+   NOTEBOOK CARD (DestinE-style)
+   ======================================== */
+
+.notebook-card {
+  display: flex;
+  align-items: flex-start;
+  border: 1px solid #cddff1;
+  border-radius: 6px;
+  padding: 14px 20px;
+  background-color: #f9fbfe;
+  box-shadow: 1px 1px 4px #dfeaf5;
+  transition: box-shadow 0.2s ease-in-out, border-color 0.2s ease-in-out;
+  text-decoration: none;
+  color: inherit;
+}
+
+.notebook-card:hover {
+  box-shadow: 0 4px 16px rgba(0, 115, 230, 0.15);
+  border-color: #7ab8f5;
+}
+
+.notebook-card .tag {
+  display: inline-block;
+  background-color: #e6f0fa;
+  border-radius: 10px;
+  padding: 3px 10px;
+  margin: 2px;
+  font-size: 0.75em;
+}
+
+/* ========================================
+   END NOTEBOOK CARD
+   ======================================== */
+
 /* Main gallery grid styling */
 .gallery-grid .sd-card,
 .notebook-grid .sd-card {

--- a/notebooks/static/gallery.css
+++ b/notebooks/static/gallery.css
@@ -13,7 +13,9 @@
   padding: 14px 20px;
   background-color: #f9fbfe;
   box-shadow: 1px 1px 4px #dfeaf5;
-  transition: box-shadow 0.2s ease-in-out, border-color 0.2s ease-in-out;
+  transition:
+    box-shadow 0.2s ease-in-out,
+    border-color 0.2s ease-in-out;
   text-decoration: none;
   color: inherit;
 }


### PR DESCRIPTION
## Summary

Adopts the DestinE-style `notebook-card` rendering for all category gallery pages, replacing the `{gallery-grid}` MyST directive blocks with inline HTML cards.

Closes #241

## Changes

### `generate_gallery.py`
- **#248** — Extract `thumbnail` from notebook YAML frontmatter; propagate through `analyze_notebooks()` and `export_metadata_for_plugin()` into `.gallery-metadata.json`
- **#249** — Add `generate_notebook_card_html()` producing DestinE-style `notebook-card` HTML (horizontal layout: thumbnail left, title/subtitle/tags/link right); add `wrap_notebook_cards()` container wrapper; add `_normalize_thumbnail()` for path normalization with fallback to EOPF logo
- **#250** — Rewrite `generate_gallery_pages()` to replace all `{gallery-grid}` directive blocks with inline `notebook-card` HTML per subsection; preserve existing tag-filter anchor links

### `notebooks/static/gallery.css`
- **#251** — Add `.notebook-card` flex layout, hover effect, and `.notebook-card .tag` chip styles

## Scope
- Category pages only: `gallery-sentinel.md`, `gallery-topics.md`, `gallery-tools.md`, `gallery-tutorials.md`
- `gallery.md` (main page) is **not** affected

## Notes
- Default thumbnail `/notebooks/static/EOPF-on-bright-baseline.png` is used for all notebooks; individual paths can be updated incrementally later